### PR TITLE
Fixes #8: Messages always encoded with 8 bytes.

### DIFF
--- a/cantools/db/formats/kcd.py
+++ b/cantools/db/formats/kcd.py
@@ -116,6 +116,8 @@ def _load_message_element(message, bus_name):
             name = value
         elif key == 'id':
             frame_id = int(value, 0)
+        elif key == 'length':
+            length = int(value)
         elif key == 'format':
             is_extended_frame = (value == 'extended')
         else:
@@ -136,7 +138,7 @@ def _load_message_element(message, bus_name):
     return Message(frame_id=frame_id,
                    is_extended_frame=is_extended_frame,
                    name=name,
-                   length=8,
+                   length=length,
                    nodes=[],
                    send_type=None,
                    cycle_time=None,

--- a/cantools/db/formats/kcd.py
+++ b/cantools/db/formats/kcd.py
@@ -1,6 +1,5 @@
 # Load and dump a CAN database in KCD format.
 import logging
-import math
 
 try:
     from StringIO import StringIO
@@ -139,7 +138,7 @@ def _load_message_element(message, bus_name):
     if length == 'auto':
         if signals:
             last_signal = sorted(signals, key=lambda s: s.start)[-1]
-            length = math.ceil((last_signal.start + last_signal.length) / 8.0)
+            length = (last_signal.start + last_signal.length + 7) // 8
         else:
             length = 0
     else:

--- a/cantools/db/message.py
+++ b/cantools/db/message.py
@@ -35,7 +35,7 @@ def _decode_signal(signal, value, decode_choices, scaling):
     return decoded_signal
 
 
-def _encode_data(data, signals, formats, scaling):
+def _encode_data(data, signals, formats, scaling, length):
     big_unpacked_data = [_encode_signal(signal, data, scaling)
                          for signal in signals
                          if signal.byte_order == 'big_endian']
@@ -47,7 +47,7 @@ def _encode_data(data, signals, formats, scaling):
     packed_union = struct.unpack('>Q', big_packed)[0]
     packed_union |= struct.unpack('>Q', little_packed)[0]
 
-    return struct.pack('>Q', packed_union)
+    return struct.pack('>Q', packed_union)[:length]
 
 
 def _decode_data(data, signals, formats, decode_choices, scaling):
@@ -292,7 +292,7 @@ class Message(object):
             signals = self._signals
             formats = self._formats
 
-        return _encode_data(data, signals, formats, scaling)
+        return _encode_data(data, signals, formats, scaling, self._length)
 
     def decode(self, data, decode_choices=True, scaling=True):
         """Decode given data as a message of this type.

--- a/tests/files/the_homer.kcd
+++ b/tests/files/the_homer.kcd
@@ -123,7 +123,7 @@
       <Signal name="SpeedKm" offset="2" length="16"/>
     </Message>
 
-    <Message id="0x400" name="Emission">
+    <Message id="0x400" length="5" name="Emission">
       <Producer>
         <NodeRef id="1"/>
         <NodeRef id="17"/>

--- a/tests/test_cantools.py
+++ b/tests/test_cantools.py
@@ -565,7 +565,22 @@ class CanToolsTest(unittest.TestCase):
         self.assertEqual(outside_temp.unit, 'Cel')
         self.assertEqual(outside_temp.choices, None)
         self.assertEqual(outside_temp.comment, 'Outside temperature.')
+        
+    def test_the_homer_encode_length(self):
+        filename = os.path.join('tests', 'files', 'the_homer.kcd')
+        db = cantools.db.load_file(filename)
 
+        frame_id = 0x400
+        data = {
+            'MIL': 0,
+            'Enginespeed': 127,
+            'NoxSensor': 127,
+        }
+
+        encoded = db.encode_message(frame_id, data)
+        self.assertEqual(len(encoded), 5)
+        self.assertEqual(encoded, b'\x00?\x80?\x80')
+        
     def test_load_bad_format(self):
         with self.assertRaises(cantools.db.UnsupportedDatabaseFormat):
             cantools.db.load(StringIO(''))

--- a/tests/test_cantools.py
+++ b/tests/test_cantools.py
@@ -489,7 +489,7 @@ class CanToolsTest(unittest.TestCase):
         self.assertEqual(db.messages[0].frame_id, 0xa)
         self.assertEqual(db.messages[0].is_extended_frame, False)
         self.assertEqual(db.messages[0].name, 'Airbag')
-        self.assertEqual(db.messages[0].length, 8)
+        self.assertEqual(db.messages[0].length, 3)
         self.assertEqual(len(db.messages[0].signals), 8)
         self.assertEqual(db.messages[0].comment, None)
         self.assertEqual(db.messages[0].send_type, None)

--- a/tests/test_cantools.py
+++ b/tests/test_cantools.py
@@ -495,6 +495,9 @@ class CanToolsTest(unittest.TestCase):
         self.assertEqual(db.messages[0].send_type, None)
         self.assertEqual(db.messages[0].cycle_time, None)
         self.assertEqual(db.messages[0].bus_name, 'Motor')
+        self.assertEqual(db.messages[3].frame_id, 0x400)
+        self.assertEqual(db.messages[3].name, 'Emission')
+        self.assertEqual(db.messages[3].length, 5)
 
         self.assertEqual(db.messages[-1].bus_name, 'Comfort')
 


### PR DESCRIPTION
Fixed by:
- Reading length attribute in kcd format.
- Shorting the returned data to specified length with python slice operator.