### PR TITLE
Support for missing or incorrect attributes in Kayak format

### DIFF
--- a/cantools/db/bus.py
+++ b/cantools/db/bus.py
@@ -7,9 +7,11 @@ class Bus(object):
 
     def __init__(self,
                  name,
-                 comment=None):
+                 comment=None,
+                 baudrate=None):
         self._name = name
         self._comment = comment
+        self._baudrate = baudrate
 
     @property
     def name(self):
@@ -26,6 +28,14 @@ class Bus(object):
         """
 
         return self._comment
+
+    @property
+    def baudrate(self):
+        """The bus baudrate, or ``None`` if unavailable.
+
+        """
+
+        return self._baudrate
 
     def __repr__(self):
         return "bus('{}', {})".format(

--- a/cantools/db/formats/kcd.py
+++ b/cantools/db/formats/kcd.py
@@ -177,7 +177,8 @@ def load_string(string):
 
     for bus in root.findall('ns:Bus', NAMESPACES):
         bus_name = bus.attrib['name']
-        buses.append(Bus(bus_name))
+        bus_baudrate = int(bus.get('baudrate', 500000))
+        buses.append(Bus(bus_name, baudrate=bus_baudrate))
 
         for message in bus.findall('ns:Message', NAMESPACES):
             messages.append(_load_message_element(message, bus_name))

--- a/cantools/db/formats/kcd.py
+++ b/cantools/db/formats/kcd.py
@@ -177,6 +177,12 @@ def load_string(string):
     nodes = [node.attrib for node in root.findall('./ns:Node', NAMESPACES)]
     buses = []
     messages = []
+    
+    try:
+        document = root.find('ns:Document', NAMESPACES)
+        version = document.attrib.get('version', None)
+    except AttributeError:
+        version = None
 
     for bus in root.findall('ns:Bus', NAMESPACES):
         bus_name = bus.attrib['name']
@@ -191,4 +197,4 @@ def load_string(string):
                     buses,
                     [],
                     [],
-                    None)
+                    version)

--- a/cantools/db/formats/kcd.py
+++ b/cantools/db/formats/kcd.py
@@ -33,7 +33,7 @@ def _load_signal_element(signal):
     name = None
     offset = None
     length = 1
-    byte_order = 'big_endian'
+    byte_order = 'little_endian'
     is_signed = False
     minimum = None
     maximum = None

--- a/cantools/db/formats/kcd.py
+++ b/cantools/db/formats/kcd.py
@@ -109,6 +109,8 @@ def _load_message_element(message, bus_name):
     frame_id = None
     is_extended_frame = False
     notes = None
+    length = 'auto'
+    interval = 0
 
     # Message XML attributes.
     for key, value in message.attrib.items():
@@ -118,11 +120,12 @@ def _load_message_element(message, bus_name):
             frame_id = int(value, 0)
         elif key == 'format':
             is_extended_frame = (value == 'extended')
+        elif key == 'length':
+            length = value  # 'auto' needs additional processing after knowing all signals
+        elif key == 'interval':
+            interval = int(value)
         else:
             LOGGER.debug("Ignoring unsupported message attribute '%s'.", key)
-            
-    length = message.attrib.get('length', 'auto')
-    interval = int(message.attrib.get('interval', 0))
 
     # Comment.
     try:

--- a/cantools/db/formats/kcd.py
+++ b/cantools/db/formats/kcd.py
@@ -122,6 +122,7 @@ def _load_message_element(message, bus_name):
             LOGGER.debug("Ignoring unsupported message attribute '%s'.", key)
             
     length = message.attrib.get('length', 'auto')
+    interval = int(message.attrib.get('interval', 0))
 
     # Comment.
     try:
@@ -150,7 +151,7 @@ def _load_message_element(message, bus_name):
                    length=length,
                    nodes=[],
                    send_type=None,
-                   cycle_time=None,
+                   cycle_time=interval,
                    signals=signals,
                    comment=notes,
                    bus_name=bus_name)

--- a/cantools/db/formats/kcd.py
+++ b/cantools/db/formats/kcd.py
@@ -81,6 +81,8 @@ def _load_signal_element(signal):
         notes = signal.find('ns:Notes', NAMESPACES).text
     except AttributeError:
         pass
+        
+    # TODO: Labels.
 
     return Signal(name=name,
                   start=offset,
@@ -126,6 +128,7 @@ def _load_message_element(message, bus_name):
             interval = int(value)
         else:
             LOGGER.debug("Ignoring unsupported message attribute '%s'.", key)
+            # TODO: triggered, count, remote
 
     # Comment.
     try:

--- a/tests/files/the_homer.kcd
+++ b/tests/files/the_homer.kcd
@@ -90,7 +90,7 @@
           <Signal name="Info7" offset="8" length="8"/>
         </MuxGroup>
       </Multiplex>
-      <Signal name="OutsideTemp" offset="18" length="12" endianess="little">
+      <Signal name="OutsideTemp" offset="18" length="12" endianess="big">
         <Notes>Outside temperature.</Notes>
         <Consumer>
           <NodeRef id="12"/>

--- a/tests/test_cantools.py
+++ b/tests/test_cantools.py
@@ -476,7 +476,7 @@ class CanToolsTest(unittest.TestCase):
         filename = os.path.join('tests', 'files', 'the_homer.kcd')
         db = cantools.db.load_file(filename)
 
-        self.assertEqual(db.version, None)
+        self.assertEqual(db.version, '1.23')
         self.assertEqual(len(db.nodes), 18)
         self.assertEqual(db.nodes[0].name, 'Motor ACME')
         self.assertEqual(db.nodes[1].name, 'Motor alternative supplier')

--- a/tests/test_cantools.py
+++ b/tests/test_cantools.py
@@ -485,6 +485,9 @@ class CanToolsTest(unittest.TestCase):
         self.assertEqual(db.buses[1].name, 'Instrumentation')
         self.assertEqual(db.buses[2].name, 'Comfort')
         self.assertEqual(db.buses[0].comment, None)
+        self.assertEqual(db.buses[0].baudrate, 500000)
+        self.assertEqual(db.buses[1].baudrate, 125000)
+        
         self.assertEqual(len(db.messages), 25)
         self.assertEqual(db.messages[0].frame_id, 0xa)
         self.assertEqual(db.messages[0].is_extended_frame, False)
@@ -503,8 +506,6 @@ class CanToolsTest(unittest.TestCase):
         self.assertEqual(db.messages[3].frame_id, 0x400)
         self.assertEqual(db.messages[3].name, 'Emission')
         self.assertEqual(db.messages[3].length, 5)
-        
-        
 
         self.assertEqual(db.messages[-1].bus_name, 'Comfort')
 

--- a/tests/test_cantools.py
+++ b/tests/test_cantools.py
@@ -493,11 +493,18 @@ class CanToolsTest(unittest.TestCase):
         self.assertEqual(len(db.messages[0].signals), 8)
         self.assertEqual(db.messages[0].comment, None)
         self.assertEqual(db.messages[0].send_type, None)
-        self.assertEqual(db.messages[0].cycle_time, None)
+        self.assertEqual(db.messages[0].cycle_time, 0)
         self.assertEqual(db.messages[0].bus_name, 'Motor')
+        
+        self.assertEqual(db.messages[1].frame_id, 0x0B2)
+        self.assertEqual(db.messages[1].name, 'ABS')
+        self.assertEqual(db.messages[1].cycle_time, 100)
+        
         self.assertEqual(db.messages[3].frame_id, 0x400)
         self.assertEqual(db.messages[3].name, 'Emission')
         self.assertEqual(db.messages[3].length, 5)
+        
+        
 
         self.assertEqual(db.messages[-1].bus_name, 'Comfort')
 

--- a/tests/test_cantools.py
+++ b/tests/test_cantools.py
@@ -515,7 +515,7 @@ class CanToolsTest(unittest.TestCase):
         self.assertEqual(seat_configuration.start, 16)
         self.assertEqual(seat_configuration.length, 8)
         self.assertEqual(seat_configuration.nodes, [])
-        self.assertEqual(seat_configuration.byte_order, 'big_endian')
+        self.assertEqual(seat_configuration.byte_order, 'little_endian')
         self.assertEqual(seat_configuration.is_signed, False)
         self.assertEqual(seat_configuration.scale, 1)
         self.assertEqual(seat_configuration.offset, 0)
@@ -531,7 +531,7 @@ class CanToolsTest(unittest.TestCase):
         self.assertEqual(tank_temperature.start, 16)
         self.assertEqual(tank_temperature.length, 16)
         self.assertEqual(tank_temperature.nodes, [])
-        self.assertEqual(tank_temperature.byte_order, 'big_endian')
+        self.assertEqual(tank_temperature.byte_order, 'little_endian')
         self.assertEqual(tank_temperature.is_signed, True)
         self.assertEqual(tank_temperature.scale, 1)
         self.assertEqual(tank_temperature.offset, 0)
@@ -547,7 +547,7 @@ class CanToolsTest(unittest.TestCase):
         self.assertEqual(speed_km.start, 30)
         self.assertEqual(speed_km.length, 24)
         self.assertEqual(speed_km.nodes, [])
-        self.assertEqual(speed_km.byte_order, 'big_endian')
+        self.assertEqual(speed_km.byte_order, 'little_endian')
         self.assertEqual(speed_km.is_signed, False)
         self.assertEqual(speed_km.scale, 0.2)
         self.assertEqual(speed_km.offset, 0)
@@ -564,7 +564,7 @@ class CanToolsTest(unittest.TestCase):
         self.assertEqual(outside_temp.start, 18)
         self.assertEqual(outside_temp.length, 12)
         self.assertEqual(outside_temp.nodes, [])
-        self.assertEqual(outside_temp.byte_order, 'little_endian')
+        self.assertEqual(outside_temp.byte_order, 'big_endian')
         self.assertEqual(outside_temp.is_signed, False)
         self.assertEqual(outside_temp.scale, 0.05)
         self.assertEqual(outside_temp.offset, -40)
@@ -587,7 +587,7 @@ class CanToolsTest(unittest.TestCase):
 
         encoded = db.encode_message(frame_id, data)
         self.assertEqual(len(encoded), 5)
-        self.assertEqual(encoded, b'\x00?\x80?\x80')
+        self.assertEqual(encoded, b'\xfe\x00\xfe\x00\x00')
         
     def test_load_bad_format(self):
         with self.assertRaises(cantools.db.UnsupportedDatabaseFormat):


### PR DESCRIPTION
Adding support for:
- Document's version attribute
- Bus' baudrate attribute
- Message's interval attribute

Also correcting the default endianess to little, as told by https://github.com/dschanoeh/Kayak/blob/master/Kayak-kcd/src/main/resources/com/github/kayak/canio/kcd/loader/Definition.xsd