### PR TITLE
Add support for float (single and double precision) in Kayak file format

### DIFF
--- a/cantools/db/formats/kcd.py
+++ b/cantools/db/formats/kcd.py
@@ -35,6 +35,7 @@ def _load_signal_element(signal):
     length = 1
     byte_order = 'little_endian'
     is_signed = False
+    is_float = False
     minimum = None
     maximum = None
     slope = 1
@@ -72,6 +73,7 @@ def _load_signal_element(signal):
                 unit = value
             elif key == 'type':
                 is_signed = (value == 'signed')
+                is_float = (value in ['single', 'double'])
             else:
                 LOGGER.debug("Ignoring unsupported signal value attribute '%s'.",
                              key)
@@ -98,7 +100,8 @@ def _load_signal_element(signal):
                   choices=None,
                   comment=notes,
                   is_multiplexer=False,
-                  multiplexer_id=None)
+                  multiplexer_id=None,
+                  is_float=is_float)
 
 
 def _load_message_element(message, bus_name):

--- a/cantools/db/message.py
+++ b/cantools/db/message.py
@@ -15,7 +15,10 @@ def _encode_signal(signal, data, scaling):
                 break
 
     if scaling:
-        return int((value - signal.offset) / signal.scale)
+        if signal.is_float:
+            return (value - signal.offset) / signal.scale
+        else:
+            return int((value - signal.offset) / signal.scale)
     else:
         return value
 
@@ -89,9 +92,9 @@ def _create_message_encode_decode_formats(signals):
         if signal.byte_order == 'little_endian':
             continue
     
-        if signal._is_float:
+        if signal.is_float:
             signal_type = 'f'
-        elif signal._is_signed:
+        elif signal.is_signed:
             signal_type = 's'
         else:
             signal_type = 'u'
@@ -115,9 +118,9 @@ def _create_message_encode_decode_formats(signals):
         if signal.byte_order == 'big_endian':
             continue
     
-        if signal._is_float:
+        if signal.is_float:
             signal_type = 'f'
-        elif signal._is_signed:
+        elif signal.is_signed:
             signal_type = 's'
         else:
             signal_type = 'u'

--- a/cantools/db/message.py
+++ b/cantools/db/message.py
@@ -87,24 +87,25 @@ def _create_message_encode_decode_formats(signals):
     # Big endian byte order format.
     big_fmt = ''
     start = 0
+    
+    def get_format_string_type(signal):
+        if signal.is_float:
+            return 'f'
+        elif signal.is_signed:
+            return 's'
+        else:
+            return 'u'
 
     for signal in signals:
         if signal.byte_order == 'little_endian':
             continue
-    
-        if signal.is_float:
-            signal_type = 'f'
-        elif signal.is_signed:
-            signal_type = 's'
-        else:
-            signal_type = 'u'
 
         padding = (signal.start - start)
 
         if padding > 0:
             big_fmt += 'p{}'.format(padding)
 
-        big_fmt += '{}{}'.format(signal_type, signal.length)
+        big_fmt += '{}{}'.format(get_format_string_type(signal), signal.length)
         start = (signal.start + signal.length)
 
     if start < 64:
@@ -117,20 +118,13 @@ def _create_message_encode_decode_formats(signals):
     for signal in signals[::-1]:
         if signal.byte_order == 'big_endian':
             continue
-    
-        if signal.is_float:
-            signal_type = 'f'
-        elif signal.is_signed:
-            signal_type = 's'
-        else:
-            signal_type = 'u'
 
         padding = end - (signal.start + signal.length)
 
         if padding > 0:
             little_fmt += 'p{}'.format(padding)
 
-        little_fmt += '{}{}'.format(signal_type, signal.length)
+        little_fmt += '{}{}'.format(get_format_string_type(signal), signal.length)
         end = signal.start
 
     if end > 0:

--- a/cantools/db/message.py
+++ b/cantools/db/message.py
@@ -77,14 +77,20 @@ def _create_message_encode_decode_formats(signals):
     for signal in signals:
         if signal.byte_order == 'little_endian':
             continue
+    
+        if signal._is_float:
+            signal_type = 'f'
+        elif signal._is_signed:
+            signal_type = 's'
+        else:
+            signal_type = 'u'
 
         padding = (signal.start - start)
 
         if padding > 0:
             big_fmt += 'p{}'.format(padding)
 
-        big_fmt += '{}{}'.format('s' if signal.is_signed else 'u',
-                                 signal.length)
+        big_fmt += '{}{}'.format(signal_type, signal.length)
         start = (signal.start + signal.length)
 
     if start < 64:
@@ -97,14 +103,20 @@ def _create_message_encode_decode_formats(signals):
     for signal in signals[::-1]:
         if signal.byte_order == 'big_endian':
             continue
+    
+        if signal._is_float:
+            signal_type = 'f'
+        elif signal._is_signed:
+            signal_type = 's'
+        else:
+            signal_type = 'u'
 
         padding = end - (signal.start + signal.length)
 
         if padding > 0:
             little_fmt += 'p{}'.format(padding)
 
-        little_fmt += '{}{}'.format('s' if signal.is_signed else 'u',
-                                    signal.length)
+        little_fmt += '{}{}'.format(signal_type, signal.length)
         end = signal.start
 
     if end > 0:

--- a/cantools/db/signal.py
+++ b/cantools/db/signal.py
@@ -21,7 +21,8 @@ class Signal(object):
                  comment,
                  nodes=None,
                  is_multiplexer=False,
-                 multiplexer_id=None):
+                 multiplexer_id=None,
+                 is_float=False):
         self._name = name
         self._start = start
         self._length = length
@@ -37,6 +38,7 @@ class Signal(object):
         self._nodes = [] if nodes is None else nodes
         self._is_multiplexer = is_multiplexer
         self._multiplexer_id = multiplexer_id
+        self._is_float = is_float
 
     @property
     def name(self):

--- a/cantools/db/signal.py
+++ b/cantools/db/signal.py
@@ -75,6 +75,7 @@ class Signal(object):
     @property
     def is_signed(self):
         """``True`` if the signal is signed, ``False`` otherwise.
+           This is ignore if ``is_float == True``.
 
         """
 

--- a/cantools/db/signal.py
+++ b/cantools/db/signal.py
@@ -81,6 +81,14 @@ class Signal(object):
         return self._is_signed
 
     @property
+    def is_float(self):
+        """``True`` if the signal is a float, ``False`` otherwise.
+
+        """
+
+        return self._is_float
+
+    @property
     def scale(self):
         """The scale factor of the signal value.
 

--- a/tests/files/the_homer.kcd
+++ b/tests/files/the_homer.kcd
@@ -361,6 +361,24 @@
       <Signal name="Guidance" offset="2" length="8"/>
     </Message>
 
+    <Message id="0x832" name="Luminosity" interval="100">
+      <Producer>
+        <NodeRef id="16"/>
+      </Producer>
+      <Signal name="AmbientLux" offset="0" length="64">
+        <Value type="double" unit="Lux" />
+      </Signal>
+    </Message>
+
+    <Message id="0x845" name="Humidity" interval="100">
+      <Producer>
+        <NodeRef id="16"/>
+      </Producer>
+      <Signal name="Windshield" offset="0" length="32">
+        <Value type="single" unit="% RH" />
+      </Signal>
+    </Message>
+
     <Message id="0xDA7E" name="DateTime" format="extended">
       <Producer>
         <NodeRef id="8"/>


### PR DESCRIPTION
Hello,

Kayak file format has value types "single" and "double" for IEE754 floats. This PR adds support for encoding and decoding these types.