### PR TITLE
added grammar for SIG_GROUP_ and optional quoted string at the end of…

### DIFF
--- a/cantools/db/formats/dbc.py
+++ b/cantools/db/formats/dbc.py
@@ -48,6 +48,7 @@ ATTRIBUTE_DEFINITION_DEFAULT_REL = 'BA_DEF_DEF_REL_'
 EVENT = 'EV_'
 SIGNAL_TYPE = 'SIG_VALTYPE_'
 SIGNAL_MULTIPLEXER_VALUES = 'SG_MUL_VAL_'
+SIGNAL_GROUP = 'SIG_GROUP_'
 
 DBC_FMT = """VERSION "{version}"
 
@@ -309,9 +310,18 @@ def _create_grammar():
                           - Keyword(SIGNAL)
                           - frame_id
                           - word
-                          - positive_integer
+                          - (positive_integer | QuotedString('"'))
                           - scolon)
     attribute_rel.setName(ATTRIBUTE_REL)
+
+    sig_group = Group(Keyword(SIGNAL_GROUP)
+                          - frame_id
+                          - word
+                          - integer
+                          - colon
+                          - OneOrMore(word)
+                          - scolon)
+    sig_group.setName(SIGNAL_GROUP)
 
     entry = (version
              | symbols
@@ -330,6 +340,7 @@ def _create_grammar():
              | attribute_definition_rel
              | attribute_definition_default_rel
              | attribute_rel
+             | sig_group
              | event)
 
     frame_id.setParseAction(lambda _s, _l, t: int(t[0]))

--- a/tests/files/foobar.dbc
+++ b/tests/files/foobar.dbc
@@ -80,5 +80,8 @@ BA_REL_ "GenSigTimeoutTime" BU_SG_REL_ MFK_3 SG_ 780 ACC_02_CRC 999;
 BA_DEF_REL_ BU_SG_REL_ "AFloat2" FLOAT 0.0 65535.0;
 BA_DEF_DEF_REL_ "AFloat2" 0.0;
 BA_REL_ "AFloat2" BU_SG_REL_ MFK_3 SG_ 780 ACC_02_CRC 999;
+BA_REL_ "AFloat2" BU_SG_REL_ MFK_3 SG_ 780 ACC_02_CRC "";
+
+SIG_GROUP_ 462 SecSomethingReq 1 : SomethingReqVal SomethingElseReqVal;
 
 

--- a/tests/test_cantools.py
+++ b/tests/test_cantools.py
@@ -1245,7 +1245,7 @@ class CanToolsTest(unittest.TestCase):
             "Invalid DBC syntax at line 1, column 1: '>!<abc': Expected "
             "{VERSION | NS_ | BS_ | BU_ | BO_ | CM_ | BA_DEF_ | BA_DEF_DEF_ "
             "| BA_ | VAL_ | VAL_TABLE_ | SIG_VALTYPE_ | SG_MUL_VAL_ "
-            "| BO_TX_BU_ | BA_DEF_REL_ | BA_DEF_DEF_REL_ | BA_REL_ | EV_}.")
+            "| BO_TX_BU_ | BA_DEF_REL_ | BA_DEF_DEF_REL_ | BA_REL_ | SIG_GROUP_ | EV_}.")
 
         # Bad message frame id.
         with self.assertRaises(cantools.db.ParseError) as cm:
@@ -1350,7 +1350,7 @@ class CanToolsTest(unittest.TestCase):
             "DBC: \"Invalid DBC syntax at line 1, column 1: \'>!<<!--\': "
             "Expected {VERSION | NS_ | BS_ | BU_ | BO_ | CM_ | BA_DEF_ | "
             "BA_DEF_DEF_ | BA_ | VAL_ | VAL_TABLE_ | SIG_VALTYPE_ | SG_MUL_VAL_ "
-            "| BO_TX_BU_ | BA_DEF_REL_ | BA_DEF_DEF_REL_ | BA_REL_ | EV_}.\"")
+            "| BO_TX_BU_ | BA_DEF_REL_ | BA_DEF_DEF_REL_ | BA_REL_ | SIG_GROUP_ | EV_}.\"")
 
         # SYM database format, but file is KCD.
         with self.assertRaises(cantools.db.UnsupportedDatabaseFormatError) as cm:


### PR DESCRIPTION
This commit fixes #22 
There was another parsing error: the SIG_GROUP_ keyword was not recognized. I added grammar for that to the best of my abilities and now at least the parsing passes without error. 