### PR TITLE
Handle named multiplexers without signals

### DIFF
--- a/cantools/db/message.py
+++ b/cantools/db/message.py
@@ -159,15 +159,19 @@ class Message(object):
                 continue
 
             if signal.is_multiplexer:
-                children_ids = []
+                children_ids = set()
 
                 for s in self._signals:
                     if s.multiplexer_signal != signal.name:
                         continue
 
-                    children_ids.extend(s.multiplexer_ids)
+                    children_ids.update(s.multiplexer_ids)
 
-                children_ids = set(children_ids)
+                # Some CAN messages will have muxes containing only the multiplexer and no additional signals.
+                # At Tesla these are indicated in advance by assigning them an enumeration. Here we ensure
+                # that any named multiplexer is included, even if it has no child id.
+                if signal.choices:
+                    children_ids.update(signal.choices.keys())
 
                 for child_id in children_ids:
                     codec = self._create_codec(signal.name, child_id)


### PR DESCRIPTION
Hi Erik,

Thank you for working on cantools! I have been using your library for just a few days now and finding it pleasant to work with. It's 3-4x faster than the CAN parser I was previously using. Good work on that. 

Note: I started using cantools by recommendation by Nick Kirkby, another Tesla engineer -- not sure if you've talked with him yet, but he's working on adopting.

Please take a look at this PR. I'm not 100% sure this is the right way to resolve for all cases -- there might be some shops who send empty muxes without enumerating mux values -- but this seemed like the least disruptive change that would suppport our needs.

See commit text below:

---

Our DBCs include messages in which, for some values of the multiplexer
signal, the multiplexer signal is the only signal included in the payload.
In those cases we indicate values that the mux ID may have by including
them in the enumeration.

The DBC entry for such messages might look like this:

```
BO_ 1000 ExampleMessage: 8
 SG_ ExampleMultiplexer M : 0|8@1+ (1,0) [0|0] ""
 SG_ AdditionalSignal m1 : 8:8@1+ (1,0) [0}0] ""

...

BA_ "FieldType" SG_ 1458 ExampleMultiplexer "ExampleMultiplexer";
VAL_ 1000 ExampleMultiplexer 5 "EVENT_TYPE_FIVE" 4 "EVENT_TYPE 4"...;
```

This commit allows us to parse messages in this category without
raising a DecodeError by including the named choice values of multiplexers
in the codec.