### PR TITLE
Add utf-8 encoding when loading dbc from file

### DIFF
--- a/cantools/db/database.py
+++ b/cantools/db/database.py
@@ -102,7 +102,7 @@ class Database(object):
 
         """
 
-        with open(filename, 'r') as fin:
+        with open(filename, 'r', encoding="utf-8") as fin:
             self.add_dbc(fin)
 
     def add_dbc_string(self, string):


### PR DESCRIPTION
This option should either be standard or at least an option since it causes errors, when extracting string information from the created database.

System: Python 3.6.5 64bit, Windows 10

It breaks python 2.7 support.