### PR TITLE
Fixed unnecessary type conversion in dump.

### DIFF
--- a/cantools/db/formats/dbc.py
+++ b/cantools/db/formats/dbc.py
@@ -529,11 +529,10 @@ def _dump_attribute_definition_defaults(database):
 
     for name, definition in definitions.items():
         if definition.default_value is not None:
-            try:
-                int(definition.default_value)
-                fmt = 'BA_DEF_DEF_  "{name}" {value};'
-            except ValueError:
+            if definition.type_name in ["STRING", "ENUM"]:
                 fmt = 'BA_DEF_DEF_  "{name}" "{value}";'
+            else:
+                fmt = 'BA_DEF_DEF_  "{name}" {value};'
 
             ba_def_def.append(fmt.format(name=definition.name,
                                          value=definition.default_value))

--- a/tests/files/attributes.dbc
+++ b/tests/files/attributes.dbc
@@ -68,7 +68,7 @@ BA_DEF_ BO_  "GenMsgSendType" ENUM  "Cyclic","NotUsed","NotUsed","NotUsed","NotU
 BA_DEF_ SG_  "GenSigInactiveValue" INT 0 100000;
 BA_DEF_ SG_  "GenSigSendType" ENUM  "Cyclic","OnWrite","OnWriteWithRepetition","OnChange","OnChangeWithRepetition","IfActive","IfActiveWithRepetition","NoSigSendType","NotUsed","NotUsed","NotUsed","NotUsed","NotUsed";
 BA_DEF_ SG_  "GenSigStartValue" FLOAT 0 100000000000;
-BA_DEF_DEF_  "TheSignalStringAttribute" "";
+BA_DEF_DEF_  "TheSignalStringAttribute" "100";
 BA_DEF_DEF_  "TheNetworkAttribute" 50;
 BA_DEF_DEF_  "TheHexAttribute" 4;
 BA_DEF_DEF_  "TheFloatAttribute" 55;

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import math
 import os
 import unittest
@@ -16,7 +17,10 @@ try:
 except ImportError:
     from io import StringIO
 
+import sys
+sys.path.append('/mnt/d/JQU/dbc/cantools')
 import cantools
+
 
 
 class CanToolsDatabaseTest(unittest.TestCase):
@@ -1755,12 +1759,11 @@ IO_DEBUG(
                          "attribute_definition('TheHexAttribute', 4)")
 
         attributes_0_0 = db.messages[0].signals[0].dbc.attributes
-        self.assertEqual(attributes_0_0['TheSignalStringAttribute'].name,
-                         'TheSignalStringAttribute')
-        self.assertEqual(attributes_0_0['TheSignalStringAttribute'].value,
-                         'TestString')
-        self.assertEqual(attributes_0_0['GenSigSendType'].name,
-                         'GenSigSendType')
+        signal_string_attribute = attributes_0_0['TheSignalStringAttribute']
+        self.assertEqual(signal_string_attribute.name, 'TheSignalStringAttribute')
+        self.assertEqual(signal_string_attribute.value, 'TestString')
+        self.assertEqual(signal_string_attribute.definition.default_value, '100')
+        self.assertEqual(attributes_0_0['GenSigSendType'].name, 'GenSigSendType')
         self.assertEqual(attributes_0_0['GenSigSendType'].value, 1)
 
         self.assertEqual(db.dbc.attributes['BusType'].name, 'BusType')

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import math
 import os
 import unittest
@@ -17,10 +16,7 @@ try:
 except ImportError:
     from io import StringIO
 
-import sys
-sys.path.append('/mnt/d/JQU/dbc/cantools')
 import cantools
-
 
 
 class CanToolsDatabaseTest(unittest.TestCase):


### PR DESCRIPTION
Handles quoting STRINGs and ENUMs correctly now.