### PR TITLE
Support for messages with no senders in dump subcommand.

### DIFF
--- a/cantools/__init__.py
+++ b/cantools/__init__.py
@@ -140,6 +140,9 @@ def _do_dump(args):
         if cycle_time is None:
             cycle_time = '-'
 
+        if len(message.senders) == 0:
+            message.senders.append('-')
+
         print()
         print('  Name:       {}'.format(message.name))
         print('  Id:         0x{:x}'.format(message.frame_id))

--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -9,9 +9,7 @@ import bitstruct
 def format_or(items):
     items = [str(item) for item in items]
 
-    if len(items) == 0:
-        return None
-    elif len(items) == 1:
+    if len(items) == 1:
         return items[0]
     else:
         return '{} or {}'.format(', '.join(items[:-1]),
@@ -21,9 +19,7 @@ def format_or(items):
 def format_and(items):
     items = [str(item) for item in items]
 
-    if len(items) == 0:
-        return None
-    elif len(items) == 1:
+    if len(items) == 1:
         return items[0]
     else:
         return '{} and {}'.format(', '.join(items[:-1]),

--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -9,7 +9,9 @@ import bitstruct
 def format_or(items):
     items = [str(item) for item in items]
 
-    if len(items) == 1:
+    if len(items) == 0:
+        return None
+    elif len(items) == 1:
         return items[0]
     else:
         return '{} or {}'.format(', '.join(items[:-1]),
@@ -19,7 +21,9 @@ def format_or(items):
 def format_and(items):
     items = [str(item) for item in items]
 
-    if len(items) == 1:
+    if len(items) == 0:
+        return None
+    elif len(items) == 1:
         return items[0]
     else:
         return '{} and {}'.format(', '.join(items[:-1]),

--- a/tests/files/no_sender.dbc
+++ b/tests/files/no_sender.dbc
@@ -34,34 +34,14 @@ NS_ :
 BS_:
 
 BU_:
-VAL_TABLE_ Vt_Pack_Configuration 7 "Slave 7" 6 "Slave 6" 5 "Slave 5" 4 "Slave 4" 3 "Slave 3" 2 "Slave 2" 1 "Slave 1" 0 "Master" ;
-VAL_TABLE_ EVT_Categorie 1 "Safety_Warning" 2 "Safety Error" 0 "Warning_Application" ;
-VAL_TABLE_ BSW 6 "ERR_EEPROM" 5 "ERR_DATASET_CRC" 4 "ERR_MASTER_SLAVE_CONFIG" 3 "ERR_INTER_COM" 2 "ERR_INTERNAL" 1 "ERR_TIMEOUT_MSG_REQ" ;
-VAL_TABLE_ detected 1 "detected" 0 "not detected" ;
-VAL_TABLE_ Fan_active 1 "Fan on" 0 "Fan off" ;
-VAL_TABLE_ Warning 1 "Warning active" 0 "No Warning" ;
-VAL_TABLE_ Error 1 "Error" 0 "No Error" ;
-VAL_TABLE_ disable_enable 1 "enable" 0 "disable" ;
-VAL_TABLE_ active_state 1 "active" 0 "inactive" ;
-VAL_TABLE_ SNA_4bit 15 "SNA" ;
-VAL_TABLE_ SNA_32bit -1 "SNA" ;
-VAL_TABLE_ SNA_24bit 16777215 "SNA" ;
-VAL_TABLE_ SNA_8bit 255 "SNA" ;
-VAL_TABLE_ SNA_16bit 65535 "SNA" ;
 
 
 BO_ 3221225472 VECTOR__INDEPENDENT_SIG_MSG: 0 Vector__XXX
- SG_ signal_without_sender : 0|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ signal_without_sender : 0|8@1- (1,0) [0|0] "" Vector__XXX
 
 
 
 CM_ BO_ 3221225472 "This is a message for not used signals, created by Vector CANdb++ DBC OLE DB Provider.";
 BA_DEF_  "BusType" STRING ;
-BA_DEF_ BO_  "GenMsgCycleTime" INT 0 65535;
-BA_DEF_ SG_  "GenSigStartValue" FLOAT -3.4E+038 3.4E+038;
-BA_DEF_DEF_  "BusType" "CAN";
-BA_DEF_DEF_  "GenMsgCycleTime" 0;
-BA_DEF_DEF_  "GenSigStartValue" 0;
-BA_ "BusType" "CAN";
-BA_ "GenSigStartValue" SG_ 3221225472 signal_without_sender 0;
+BA_DEF_DEF_  "BusType" "";
 

--- a/tests/files/no_sender.dbc
+++ b/tests/files/no_sender.dbc
@@ -1,0 +1,67 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_:
+VAL_TABLE_ Vt_Pack_Configuration 7 "Slave 7" 6 "Slave 6" 5 "Slave 5" 4 "Slave 4" 3 "Slave 3" 2 "Slave 2" 1 "Slave 1" 0 "Master" ;
+VAL_TABLE_ EVT_Categorie 1 "Safety_Warning" 2 "Safety Error" 0 "Warning_Application" ;
+VAL_TABLE_ BSW 6 "ERR_EEPROM" 5 "ERR_DATASET_CRC" 4 "ERR_MASTER_SLAVE_CONFIG" 3 "ERR_INTER_COM" 2 "ERR_INTERNAL" 1 "ERR_TIMEOUT_MSG_REQ" ;
+VAL_TABLE_ detected 1 "detected" 0 "not detected" ;
+VAL_TABLE_ Fan_active 1 "Fan on" 0 "Fan off" ;
+VAL_TABLE_ Warning 1 "Warning active" 0 "No Warning" ;
+VAL_TABLE_ Error 1 "Error" 0 "No Error" ;
+VAL_TABLE_ disable_enable 1 "enable" 0 "disable" ;
+VAL_TABLE_ active_state 1 "active" 0 "inactive" ;
+VAL_TABLE_ SNA_4bit 15 "SNA" ;
+VAL_TABLE_ SNA_32bit -1 "SNA" ;
+VAL_TABLE_ SNA_24bit 16777215 "SNA" ;
+VAL_TABLE_ SNA_8bit 255 "SNA" ;
+VAL_TABLE_ SNA_16bit 65535 "SNA" ;
+
+
+BO_ 3221225472 VECTOR__INDEPENDENT_SIG_MSG: 0 Vector__XXX
+ SG_ signal_without_sender : 0|1@1+ (1,0) [0|1] "" Vector__XXX
+
+
+
+CM_ BO_ 3221225472 "This is a message for not used signals, created by Vector CANdb++ DBC OLE DB Provider.";
+BA_DEF_  "BusType" STRING ;
+BA_DEF_ BO_  "GenMsgCycleTime" INT 0 65535;
+BA_DEF_ SG_  "GenSigStartValue" FLOAT -3.4E+038 3.4E+038;
+BA_DEF_DEF_  "BusType" "CAN";
+BA_DEF_DEF_  "GenMsgCycleTime" 0;
+BA_DEF_DEF_  "GenSigStartValue" 0;
+BA_ "BusType" "CAN";
+BA_ "GenSigStartValue" SG_ 3221225472 signal_without_sender 0;
+

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -838,7 +838,7 @@ IO_DEBUG(
   Name:       VECTOR__INDEPENDENT_SIG_MSG
   Id:         0x40000000
   Length:     0 bytes
-  Cycle time: 0 ms
+  Cycle time: - ms
   Senders:    -
   Layout:
 
@@ -846,9 +846,9 @@ IO_DEBUG(
 
              7   6   5   4   3   2   1   0
            +---+---+---+---+---+---+---+---+
-     B   0 |   |   |   |   |   |   |   |<-x|
+     B   0 |<-----------------------------x|
      y     +---+---+---+---+---+---+---+---+
-     t                                   +-- signal_without_sender
+     t       +-- signal_without_sender
      e
 
   Signal tree:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -822,6 +822,51 @@ IO_DEBUG(
                 actual_output = stdout.getvalue()
                 self.assertEqual(actual_output, expected_output)
 
+    def test_command_line_dump_no_sender(self):
+        argv = [
+            'cantools',
+            'dump',
+            '--no-strict',
+            'tests/files/no_sender.dbc'
+        ]
+
+        expected_output = """\
+================================= Messages =================================
+
+  ------------------------------------------------------------------------
+
+  Name:       VECTOR__INDEPENDENT_SIG_MSG
+  Id:         0x40000000
+  Length:     0 bytes
+  Cycle time: 0 ms
+  Senders:    -
+  Layout:
+
+                          Bit
+
+             7   6   5   4   3   2   1   0
+           +---+---+---+---+---+---+---+---+
+     B   0 |   |   |   |   |   |   |   |<-x|
+     y     +---+---+---+---+---+---+---+---+
+     t                                   +-- signal_without_sender
+     e
+
+  Signal tree:
+
+    -- {root}
+       +-- signal_without_sender
+
+  ------------------------------------------------------------------------
+"""
+
+        stdout = StringIO()
+
+        with patch('sys.stdout', stdout):
+            with patch('sys.argv', argv):
+                cantools._main()
+                actual_output = stdout.getvalue()
+                self.assertEqual(actual_output, expected_output)
+
     def test_command_line_convert(self):
         # DBC to KCD.
         argv = [


### PR DESCRIPTION
Vector's CANdb++ tool can create .dbc-files containing messages with no senders. The cantools dump subcommand currently chokes on such files. This change adds support for messages with no senders.

Technically, only the format_and function needs to be changed, but I also changed the format_or function for consistency and robustness.