### PR TITLE
Parse numbers as Decimals in more situations to relax parser on some DBCs

### DIFF
--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -616,9 +616,9 @@ def _load_attributes(tokens, definitions):
 
         definition = definitions[attribute[1]]
 
-        if definition.type_name in ['INT', 'HEX', 'ENUM']:
+        if definition.type_name in ['HEX', 'ENUM']:
             value = int(value)
-        elif definition.type_name == 'FLOAT':
+        elif definition.type_name in ['INT', 'FLOAT']:
             value = Decimal(value)
 
         return Attribute(value=value,

--- a/tests/files/decimal.dbc
+++ b/tests/files/decimal.dbc
@@ -1,0 +1,38 @@
+VERSION ""
+
+NS_ :
+        NS_DESC_
+        CM_
+        BA_DEF_
+        BA_
+        VAL_
+        CAT_DEF_
+        CAT_
+        FILTER
+        BA_DEF_DEF_
+        EV_DATA_
+        ENVVAR_DATA_
+        SGTYPE_
+        SGTYPE_VAL_
+        BA_DEF_SGTYPE_
+        BA_SGTYPE_
+        SIG_TYPE_REF_
+        VAL_TABLE_
+        SIG_GROUP_
+        SIG_VALTYPE_
+        SIGTYPE_VALTYPE_
+        BO_TX_BU_
+        BA_DEF_REL_
+        BA_REL_
+        BA_DEF_DEF_REL_
+        BU_SG_REL_
+        BU_EV_REL_
+        BU_BO_REL_
+        SG_MUL_VAL_
+
+BS_:
+
+
+BA_DEF_ "Definition1" INT 0 1000000;
+
+BA_ "Definition1" SG_ 999 VAL_decimal 655.35;

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -759,6 +759,30 @@ IO_DEBUG(
                     actual_output = stdout.getvalue()
                     self.assertEqual(actual_output, expected_output)
 
+    def test_decimal_parsing_dump(self):
+        """Do not error on a DBC that uses a decimal value on a INT attribute, some DBCs do that.
+
+        """
+
+        argv = [
+            'cantools',
+            'dump',
+            'tests/files/decimal.dbc'
+        ]
+
+        expected_output = """\
+================================= Messages =================================
+
+  ------------------------------------------------------------------------
+"""
+        stdout = StringIO()
+
+        with patch('sys.stdout', stdout):
+            with patch('sys.argv', argv):
+                cantools._main()
+                actual_output = stdout.getvalue()
+                self.assertEqual(actual_output, expected_output)
+
     def test_command_line_dump(self):
         argv = [
             'cantools',


### PR DESCRIPTION
Some DBCs define some signals attributes as INT but later on use a decimal value in BA_.

This parses every number as Decimal, which solves the parsing errors and has no noticeable
side effect I could tell.