### PR TITLE
Fix bitstruct dependency version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(name='cantools',
       url='https://github.com/eerimoq/cantools',
       packages=find_packages(exclude=['tests']),
       install_requires=[
-          'bitstruct>=3.7.0',
+          'bitstruct>=6.0.0',
           'pyparsing>=2.0.3',
           'python-can>=2.1.0',
           'textparser',


### PR DESCRIPTION
Hi,

After updating to the latest version of `cantools` (`29.2.0`) I was getting the following error when dumping a DBC file.

```
 → TITANIC@dbc-testing ((master)) $ cantools dump test.dbc
error: compile() takes 1 positional argument but 2 were given
```

Bisecting led me to this commit, in which the `bitstruct` `dict` methods are used.

```
 → TITANIC@cantools ((ef9a361...)|BISECTING) $ git bisect good
f488da1bf255aed6531b2b98ccabd5623bb5eef7 is the first bad commit
commit f488da1bf255aed6531b2b98ccabd5623bb5eef7
Author: Erik Moqvist <erik.moqvist@gmail.com>
Date:   Sun Nov 18 19:10:26 2018 +0100

    Use bitstruct dict methods.

:040000 040000 c9a6034f0179a0b241dc35ef49cf63ba973db651 12032415af5644904cb82eb29077668bba9cdbbd M      cantools
```

However, due to the old version of `bitstruct` I had installed, it meets the version requirements specified in `setup.py`, and so it wasn't updated with your latest changes.

This bumps the version requirement on `bitstruct`.