### PR TITLE
Add .PHONY targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: test
 test:
 	python2 setup.py test
 	python3 setup.py test
@@ -9,6 +10,7 @@ test:
 	codespell -d $$(git ls-files | grep -v \.kcd | grep -v \.[hc])
 	$(MAKE) test_c
 
+.PHONY: test_c
 test_c:
 	gcc -Wall -Wpedantic -Werror -std=c99 \
 	    tests/main.c \
@@ -20,6 +22,7 @@ test_c:
 	    tests/files/c_source/no_signals.c \
 	    tests/files/c_source/choices.c && ./a.out
 
+.PHONY: test-sdist
 test-sdist:
 	rm -rf dist
 	python setup.py sdist
@@ -30,6 +33,7 @@ test-sdist:
 	cd cantools-* && \
 	python setup.py test
 
+.PHONY: release-to-pypi
 release-to-pypi:
 	python setup.py sdist
 	python setup.py bdist_wheel --universal


### PR DESCRIPTION
Currently the `Makefile` does not specify a `.PHONY` target, which causes `make` to treat the target as a file. Since the current `make` targets `{test,test_c,test-sdist,release-to-pypi}` do not create these target files, if a file of the same name exists in the repository the target will not work correctly (and will not run).

```bash
# Make a folder called test
# (I was using this for storing some DBC files I was testing)
mkdir -p test
# Doesn't do anything since the prerequisite is already fulfilled
make test
```

Adding `.PHONY` specifies that the target is not a file, such that the target will run the recipe regardless of whether there is a file of the same name.