### PR TITLE
Enable -Wextra warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ test-c:
 	    -Wpedantic \
 	    -Werror \
 	    -Wextra \
+	    -Wno-type-limits \
+	    -Wno-unused-parameter \
 	    -std=c99 \
 	    tests/main.c \
 	    tests/files/c_source/motohawk.c \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,12 @@ test:
 
 .PHONY: test-c
 test-c:
-	gcc -Wall -Wpedantic -Werror -std=c99 \
+	gcc \
+	    -Wall \
+	    -Wpedantic \
+	    -Werror \
+	    -Wextra \
+	    -std=c99 \
 	    tests/main.c \
 	    tests/files/c_source/motohawk.c \
 	    tests/files/c_source/padding_bit_order.c \


### PR DESCRIPTION
Add `-Wextra` flag as per discussion in #76.

There may be additional warnings not covered by `-Wall -Werror -Wextra -Wpedantic` that might also be useful to enable.