### PR TITLE
Add GCC8 support in Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ script:
   - env PYTHONPATH=. python examples/hello_world.py
   - env PYTHONPATH=. python examples/diagnostics/did.py
   - make test-c
-  - make test-c-gcc-8
+  - CC=gcc-8 make test-c
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,17 @@ language: python
 python:
   - "2.7"
   - "3.6"
+addons:
+  apt:
+    update: true
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-8
 install:
   - pip install coveralls
   - pip install -r requirements.txt
+  - gcc-8 --version
 script:
   - coverage run --source=cantools setup.py test
   - make test-sdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ script:
   - env PYTHONPATH=. python examples/hello_world.py
   - env PYTHONPATH=. python examples/diagnostics/did.py
   - make test-c
+  - make test-c-gcc-8
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
 install:
   - pip install coveralls
   - pip install -r requirements.txt
-  - gcc-8 --version
 script:
   - coverage run --source=cantools setup.py test
   - make test-sdist

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,24 @@
+# C source files
+C_SOURCES := \
+	    tests/main.c \
+	    tests/files/c_source/motohawk.c \
+	    tests/files/c_source/padding_bit_order.c \
+	    tests/files/c_source/vehicle.c \
+	    tests/files/c_source/multiplex.c \
+	    tests/files/c_source/multiplex_2.c \
+	    tests/files/c_source/floating_point.c \
+	    tests/files/c_source/no_signals.c \
+	    tests/files/c_source/choices.c \
+	    tests/files/c_source/signed.c
+
+CFLAGS := \
+	    -Wall \
+	    -Wextra \
+	    -Wpedantic \
+	    -Wlogical-op \
+	    -Wdouble-promotion \
+	    -Werror
+
 .PHONY: test
 test:
 	python2 setup.py test
@@ -13,24 +34,10 @@ test:
 .PHONY: test-c
 test-c:
 	gcc \
-	    -Wall \
-	    -Wextra \
-	    -Wpedantic \
-	    -Wlogical-op \
-	    -Wdouble-promotion \
-	    -Werror \
+	    $(CFLAGS) \
 	    -std=c99 \
 	    -O3 \
-	    tests/main.c \
-	    tests/files/c_source/motohawk.c \
-	    tests/files/c_source/padding_bit_order.c \
-	    tests/files/c_source/vehicle.c \
-	    tests/files/c_source/multiplex.c \
-	    tests/files/c_source/multiplex_2.c \
-	    tests/files/c_source/floating_point.c \
-	    tests/files/c_source/no_signals.c \
-	    tests/files/c_source/choices.c \
-	    tests/files/c_source/signed.c
+	    $(C_SOURCES)
 	./a.out
 
 .PHONY: test-sdist

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-CC := gcc
-CC_NEW := gcc-8
+ifeq ($(origin CC),default)
+CC = gcc
+endif
 
 # C source files
 C_SOURCES := \
@@ -14,26 +15,21 @@ C_SOURCES := \
 	    tests/files/c_source/choices.c \
 	    tests/files/c_source/signed.c
 
+CFLAGS_EXTRA := \
+	    -Wduplicated-branches \
+	    -Wduplicated-cond \
+	    -Wjump-misses-init \
+	    -Wlogical-op \
+	    -Wnull-dereference \
+	    -Wrestrict
+
 CFLAGS := \
 	    -Wall \
 	    -Wextra \
 	    -Wpedantic \
 	    -Wdouble-promotion \
-	    -Wjump-misses-init \
-	    -Wlogical-op \
 	    -Werror
-
-# CFLAGS added in GCC 6
-CFLAGS_GCC6 := \
-	    -Wduplicated-cond \
-
-# CFLAGS added in GCC 7
-CFLAGS_GCC7 := \
-	    -Wduplicated-branches \
-	    -Wrestrict
-
-CFLAGS_GCC8 := \
-	    -Wnull-dereference
+CFLAGS += $(shell $(CC) -Werror $(CFLAGS_EXTRA) -c tests/dummy.c 2> /dev/null && echo $(CFLAGS_EXTRA))
 
 .PHONY: test
 test:
@@ -51,18 +47,6 @@ test:
 test-c:
 	$(CC) \
 	    $(CFLAGS) \
-	    -std=c99 \
-	    -O3 \
-	    $(C_SOURCES)
-	./a.out
-
-.PHONY: test-c-gcc-8
-test-c-gcc-8:
-	$(CC_NEW) \
-	    $(CFLAGS) \
-	    $(CFLAGS_GCC6) \
-	    $(CFLAGS_GCC7) \
-	    $(CFLAGS_GCC8) \
 	    -std=c99 \
 	    -O3 \
 	    $(C_SOURCES)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+CC := gcc
+CC_NEW := gcc-8
+
 # C source files
 C_SOURCES := \
 	    tests/main.c \
@@ -15,9 +18,22 @@ CFLAGS := \
 	    -Wall \
 	    -Wextra \
 	    -Wpedantic \
-	    -Wlogical-op \
 	    -Wdouble-promotion \
+	    -Wjump-misses-init \
+	    -Wlogical-op \
 	    -Werror
+
+# CFLAGS added in GCC 6
+CFLAGS_GCC6 := \
+	    -Wduplicated-cond \
+
+# CFLAGS added in GCC 7
+CFLAGS_GCC7 := \
+	    -Wduplicated-branches \
+	    -Wrestrict
+
+CFLAGS_GCC8 := \
+	    -Wnull-dereference
 
 .PHONY: test
 test:
@@ -33,8 +49,20 @@ test:
 
 .PHONY: test-c
 test-c:
-	gcc \
+	$(CC) \
 	    $(CFLAGS) \
+	    -std=c99 \
+	    -O3 \
+	    $(C_SOURCES)
+	./a.out
+
+.PHONY: test-c-gcc-8
+test-c-gcc-8:
+	$(CC_NEW) \
+	    $(CFLAGS) \
+	    $(CFLAGS_GCC6) \
+	    $(CFLAGS_GCC7) \
+	    $(CFLAGS_GCC8) \
 	    -std=c99 \
 	    -O3 \
 	    $(C_SOURCES)

--- a/Makefile
+++ b/Makefile
@@ -4,31 +4,31 @@ endif
 
 # C source files
 C_SOURCES := \
-	    tests/main.c \
-	    tests/files/c_source/motohawk.c \
-	    tests/files/c_source/padding_bit_order.c \
-	    tests/files/c_source/vehicle.c \
-	    tests/files/c_source/multiplex.c \
-	    tests/files/c_source/multiplex_2.c \
-	    tests/files/c_source/floating_point.c \
-	    tests/files/c_source/no_signals.c \
-	    tests/files/c_source/choices.c \
-	    tests/files/c_source/signed.c
+	tests/main.c \
+	tests/files/c_source/motohawk.c \
+	tests/files/c_source/padding_bit_order.c \
+	tests/files/c_source/vehicle.c \
+	tests/files/c_source/multiplex.c \
+	tests/files/c_source/multiplex_2.c \
+	tests/files/c_source/floating_point.c \
+	tests/files/c_source/no_signals.c \
+	tests/files/c_source/choices.c \
+	tests/files/c_source/signed.c
 
 CFLAGS_EXTRA := \
-	    -Wduplicated-branches \
-	    -Wduplicated-cond \
-	    -Wjump-misses-init \
-	    -Wlogical-op \
-	    -Wnull-dereference \
-	    -Wrestrict
+	-Wduplicated-branches \
+	-Wduplicated-cond \
+	-Wjump-misses-init \
+	-Wlogical-op \
+	-Wnull-dereference \
+	-Wrestrict
 
 CFLAGS := \
-	    -Wall \
-	    -Wextra \
-	    -Wpedantic \
-	    -Wdouble-promotion \
-	    -Werror
+	-Wall \
+	-Wextra \
+	-Wpedantic \
+	-Wdouble-promotion \
+	-Werror
 CFLAGS += $(shell $(CC) -Werror $(CFLAGS_EXTRA) -c tests/dummy.c 2> /dev/null && echo $(CFLAGS_EXTRA))
 
 .PHONY: test

--- a/tests/dummy.c
+++ b/tests/dummy.c
@@ -3,7 +3,8 @@
  * CFLAGS can be added. It is imperative that this always will compile
  * correctly, in order to give accurate results.
  */
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[])
+{
   (void)argc;
   (void)argv;
 

--- a/tests/dummy.c
+++ b/tests/dummy.c
@@ -1,0 +1,11 @@
+/**
+ * This file is a dummy file whose sole purpose is to determine which set of
+ * CFLAGS can be added. It is imperative that this always will compile
+ * correctly, in order to give accurate results.
+ */
+int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+
+  return 0;
+}


### PR DESCRIPTION
This change adds GCC 8 support in Travis CI.

Let me know if there's some `Makefile` style things you want changed&mdash;the `CC` variable can probably be passed in the `.travis.yml` file, and a separate variable can be used to identify the version (if binaries are named differently) and determine which warnings to enable (which would get rid of this CI-only target).