### PR TITLE
Fix floating point comparison usage in test harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,9 @@ CFLAGS := \
 	-Wall \
 	-Wextra \
 	-Wpedantic \
-	-Wdouble-promotion \
 	-Wconversion \
+	-Wdouble-promotion \
+	-Wfloat-equal \
 	-Werror
 CFLAGS += $(shell $(CC) -Werror $(CFLAGS_EXTRA) -c tests/dummy.c 2> /dev/null && echo $(CFLAGS_EXTRA))
 

--- a/tests/main.c
+++ b/tests/main.c
@@ -12,21 +12,6 @@
 #include "files/c_source/no_signals.h"
 #include "files/c_source/signed.h"
 
-#define FLOATING_ERROR_DOUBLE (0.00001)
-#define FLOATING_ERROR_FLOAT (0.1f)
-
-#define FLOATING_APPROX_EQUAL(val1, val2, epsilon) \
-  do { \
-    assert((((val1) - (epsilon)) < (val2))); \
-    assert((((val1) + (epsilon)) > (val2))); \
-  } while (0)
-
-#define FLOATING_APPROX_EQUAL_FLOAT(val1, val2) \
-  FLOATING_APPROX_EQUAL((val1), (val2), FLOATING_ERROR_FLOAT)
-
-#define FLOATING_APPROX_EQUAL_DOUBLE(val1, val2) \
-  FLOATING_APPROX_EQUAL((val1), (val2), FLOATING_ERROR_DOUBLE)
-
 static void test_motohawk_example_message(void)
 {
     struct {
@@ -371,10 +356,11 @@ static void test_multiplex_2_extended(void)
 
 static void test_floating_point_message1(void)
 {
+    double signal1 = -129.448;
     struct floating_point_message1_t decoded;
     uint8_t buf[8];
 
-    decoded.signal1 = -129.448;
+    decoded.signal1 = signal1;
 
     memset(&buf[0], 0, sizeof(buf));
     assert(floating_point_message1_encode(&buf[0],
@@ -387,16 +373,18 @@ static void test_floating_point_message1(void)
     assert(floating_point_message1_decode(&decoded,
                                           &buf[0],
                                           sizeof(buf)) == 0);
-    FLOATING_APPROX_EQUAL_DOUBLE(decoded.signal1, -129.448);
+    assert(memcmp(&decoded.signal1, &signal1, sizeof(decoded.signal1)) == 0);
 }
 
 static void test_floating_point_message2(void)
 {
+    float signal1 = 129.5f;
+    float signal2 = 1234500.5f;
     struct floating_point_message2_t decoded;
     uint8_t buf[8];
 
-    decoded.signal1 = 129.5;
-    decoded.signal2 = 1234500.5;
+    decoded.signal1 = signal1;
+    decoded.signal2 = signal2;
 
     memset(&buf[0], 0, sizeof(buf));
     assert(floating_point_message2_encode(&buf[0],
@@ -409,8 +397,9 @@ static void test_floating_point_message2(void)
     assert(floating_point_message2_decode(&decoded,
                                           &buf[0],
                                           sizeof(buf)) == 0);
-    FLOATING_APPROX_EQUAL_FLOAT(decoded.signal1, 129.5f);
-    FLOATING_APPROX_EQUAL_FLOAT(decoded.signal2, 1234500.5f);
+
+    assert(memcmp(&decoded.signal1, &signal1, sizeof(decoded.signal1)) == 0);
+    assert(memcmp(&decoded.signal2, &signal2, sizeof(decoded.signal2)) == 0);
 }
 
 static void test_floating_point(void)

--- a/tests/main.c
+++ b/tests/main.c
@@ -12,6 +12,21 @@
 #include "files/c_source/no_signals.h"
 #include "files/c_source/signed.h"
 
+#define FLOATING_ERROR_DOUBLE (0.00001)
+#define FLOATING_ERROR_FLOAT (0.1f)
+
+#define FLOATING_APPROX_EQUAL(val1, val2, epsilon) \
+  do { \
+    assert((((val1) - (epsilon)) < (val2))); \
+    assert((((val1) + (epsilon)) > (val2))); \
+  } while (0)
+
+#define FLOATING_APPROX_EQUAL_FLOAT(val1, val2) \
+  FLOATING_APPROX_EQUAL((val1), (val2), FLOATING_ERROR_FLOAT)
+
+#define FLOATING_APPROX_EQUAL_DOUBLE(val1, val2) \
+  FLOATING_APPROX_EQUAL((val1), (val2), FLOATING_ERROR_DOUBLE)
+
 static void test_motohawk_example_message(void)
 {
     struct {
@@ -372,7 +387,7 @@ static void test_floating_point_message1(void)
     assert(floating_point_message1_decode(&decoded,
                                           &buf[0],
                                           sizeof(buf)) == 0);
-    assert(decoded.signal1 == -129.448);
+    FLOATING_APPROX_EQUAL_DOUBLE(decoded.signal1, -129.448);
 }
 
 static void test_floating_point_message2(void)
@@ -394,8 +409,8 @@ static void test_floating_point_message2(void)
     assert(floating_point_message2_decode(&decoded,
                                           &buf[0],
                                           sizeof(buf)) == 0);
-    assert(decoded.signal1 == 129.5f);
-    assert(decoded.signal2 == 1234500.5f);
+    FLOATING_APPROX_EQUAL_FLOAT(decoded.signal1, 129.5f);
+    FLOATING_APPROX_EQUAL_FLOAT(decoded.signal2, 1234500.5f);
 }
 
 static void test_floating_point(void)
@@ -595,7 +610,7 @@ static void test_is_in_range(void)
     assert(motohawk_example_message_temperature_is_in_range(2048) == false);
 }
 
-int main()
+int main(void)
 {
     test_motohawk_example_message();
     test_padding_bit_order();


### PR DESCRIPTION
Floating point numbers should not be directly compared. Instead, they
should be compared against an epsilon value which denotes the maximum
allowed error.