### PR TITLE
extend .gitignore with Vim and IntelliJ IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ a.out
 # Distribution / packaging
 .Python
 env/
+venv/
+.venv/
 build/
 develop-eggs/
 dist/
@@ -57,6 +59,14 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Vim IDE
+*~
+*.swp
+*.swo
+
+# IntelliJ IDEA
+.idea/
 
 # CANdb++
 /tests/files/*.ini


### PR DESCRIPTION
PyCharm is a common used Python IDE that generates some files
that have nothing to do with the project.

Also added `venv/` and `.venv/` folders since some python virtual
environment tools create this folders instead of `env/`.