### PR TITLE
DBC parsing: add support for Environment Variables

### DIFF
--- a/cantools/database/can/environment_variable.py
+++ b/cantools/database/can/environment_variable.py
@@ -1,0 +1,161 @@
+# A CAN environment variable.
+
+class EnvironmentVariable(object):
+    """A CAN environment variable.
+
+    """
+
+    def __init__(self,
+                 name,
+                 env_type,
+                 minimum,
+                 maximum,
+                 unit,
+                 initial_value,
+                 env_id,
+                 access_type,
+                 access_node,
+                 comment):
+        self._name = name
+        self._env_type = env_type
+        self._minimum = minimum
+        self._maximum = maximum
+        self._unit = unit
+        self._initial_value = initial_value
+        self._env_id = env_id
+        self._access_type = access_type
+        self._access_node = access_node
+        self._comment = comment
+
+    @property
+    def name(self):
+        """The environment variable name as a string.
+
+        """
+
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+
+    @property
+    def env_type(self):
+        """The environment variable type value.
+
+        """
+
+        return self._env_type
+
+    @env_type.setter
+    def env_type(self, value):
+        self._env_type = value
+
+    @property
+    def minimum(self):
+        """The minimum value of the environment variable.
+
+        """
+
+        return self._minimum
+
+    @minimum.setter
+    def minimum(self, value):
+        self._minimum = value
+
+    @property
+    def maximum(self):
+        """The maximum value of the environment variable.
+
+        """
+
+        return self._maximum
+
+    @maximum.setter
+    def maximum(self, value):
+        self._maximum = value
+
+    @property
+    def unit(self):
+        """ The units in which the environment variable is expressed as a string.
+
+        """
+
+        return self._unit
+
+    @unit.setter
+    def unit(self, value):
+        self._unit = value
+
+    @property
+    def initial_value(self):
+        """The initial value of the environment variable.
+
+        """
+
+        return self._initial_value
+
+    @initial_value.setter
+    def initial_value(self, value):
+        self._initial_value = value
+
+    @property
+    def env_id(self):
+        """The id value of the environment variable.
+
+        """
+
+        return self._env_id
+
+    @env_id.setter
+    def env_id(self, value):
+        self._env_id = value
+
+    @property
+    def access_type(self):
+        """The environment variable access type as a string.
+
+        """
+
+        return self._access_type
+
+    @access_type.setter
+    def access_type(self, value):
+        self._access_type = value
+
+    @property
+    def access_node(self):
+        """The environment variable access node as a string.
+
+        """
+
+        return self._access_node
+
+    @access_node.setter
+    def access_node(self, value):
+        self._access_node = value
+
+    @property
+    def comment(self):
+        """The environment variable comment, or ``None`` if unavailable.
+
+        """
+
+        return self._comment
+
+    @comment.setter
+    def comment(self, value):
+        self._comment = value
+
+    def __repr__(self):
+        return "environment_variable('{}', {}, {}, {}, '{}', {}, {}, '{}', '{}', {})".format(
+            self._name,
+            self._env_type,
+            self._minimum,
+            self._maximum,
+            self._unit,
+            self._initial_value,
+            self._env_id,
+            self._access_type,
+            self._access_node,
+            "'" + self._comment + "'" if self._comment is not None else None)

--- a/cantools/database/can/environment_variable.py
+++ b/cantools/database/can/environment_variable.py
@@ -1,5 +1,3 @@
-# A CAN environment variable.
-
 class EnvironmentVariable(object):
     """A CAN environment variable.
 
@@ -34,10 +32,6 @@ class EnvironmentVariable(object):
         """
 
         return self._name
-
-    @name.setter
-    def name(self, value):
-        self._name = value
 
     @property
     def env_type(self):

--- a/tests/files/emc32.dbc
+++ b/tests/files/emc32.dbc
@@ -80,3 +80,5 @@ EV_ EMC_Action_2: 0 [0|1] "" 0 16 DUMMY_NODE_VECTOR0 Vector__XXX;
 EV_ EMC_Action_1: 0 [0|1] "" 0 17 DUMMY_NODE_VECTOR0 Vector__XXX;
 
 
+CM_ EV_ EMC_Azimuth "Elevation Head";
+

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -98,6 +98,19 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(db.messages[0].signals[1].name, 'EMV_Aktion_Status_4')
         self.assertEqual(len(db.messages[0].signals[1].receivers), 0)
 
+        self.assertEqual(len(db.dbc.environment_variables), 17)
+        env_var = db.dbc.environment_variables['EMC_Azimuth']
+        self.assertEqual(env_var.name, 'EMC_Azimuth')
+        self.assertEqual(env_var.env_type, 1)
+        self.assertEqual(env_var.minimum, -180)
+        self.assertEqual(env_var.maximum, 400)
+        self.assertEqual(env_var.unit, 'deg')
+        self.assertEqual(env_var.initial_value, 0)
+        self.assertEqual(env_var.env_id, 12)
+        self.assertEqual(env_var.access_type, 'DUMMY_NODE_VECTOR0')
+        self.assertEqual(env_var.access_node, 'Vector__XXX')
+        self.assertEqual(env_var.comment, None)
+
     def test_foobar(self):
         db = cantools.db.Database()
         filename = os.path.join('tests', 'files', 'foobar.dbc')

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -99,17 +99,50 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(len(db.messages[0].signals[1].receivers), 0)
 
         self.assertEqual(len(db.dbc.environment_variables), 17)
-        env_var = db.dbc.environment_variables['EMC_Azimuth']
-        self.assertEqual(env_var.name, 'EMC_Azimuth')
-        self.assertEqual(env_var.env_type, 1)
-        self.assertEqual(env_var.minimum, -180)
-        self.assertEqual(env_var.maximum, 400)
-        self.assertEqual(env_var.unit, 'deg')
-        self.assertEqual(env_var.initial_value, 0)
-        self.assertEqual(env_var.env_id, 12)
-        self.assertEqual(env_var.access_type, 'DUMMY_NODE_VECTOR0')
-        self.assertEqual(env_var.access_node, 'Vector__XXX')
-        self.assertEqual(env_var.comment, None)
+        env_var_1 = db.dbc.environment_variables['EMC_Azimuth']
+        self.assertEqual(env_var_1.name, 'EMC_Azimuth')
+        self.assertEqual(env_var_1.env_type, 1)
+        self.assertEqual(env_var_1.minimum, -180)
+        self.assertEqual(env_var_1.maximum, 400)
+        self.assertEqual(env_var_1.unit, 'deg')
+        self.assertEqual(env_var_1.initial_value, 0)
+        self.assertEqual(env_var_1.env_id, 12)
+        self.assertEqual(env_var_1.access_type, 'DUMMY_NODE_VECTOR0')
+        self.assertEqual(env_var_1.access_node, 'Vector__XXX')
+        self.assertEqual(env_var_1.comment, 'Elevation Head')
+        self.assertEqual(
+            repr(env_var_1),
+            "environment_variable('EMC_Azimuth', 1, -180, 400, 'deg', 0, 12,"
+            " 'DUMMY_NODE_VECTOR0', 'Vector__XXX', 'Elevation Head')")
+
+        env_var_2 = db.dbc.environment_variables['EMC_TrdPower']
+        self.assertEqual(env_var_2.name, 'EMC_TrdPower')
+        self.assertEqual(env_var_2.comment, None)
+        #
+        # Test setters
+        env_var_2.env_type = 1
+        env_var_2.minimum = -180
+        env_var_2.maximum = 400
+        env_var_2.unit = 'deg'
+        env_var_2.initial_value = 0
+        env_var_2.env_id = 12
+        env_var_2.access_type = 'DUMMY_NODE_VECTOR0'
+        env_var_2.access_node = 'Vector__XXX'
+        env_var_2.comment = 'Elevation Head'
+        self.assertEqual(env_var_2.env_type, 1)
+        self.assertEqual(env_var_2.minimum, -180)
+        self.assertEqual(env_var_2.maximum, 400)
+        self.assertEqual(env_var_2.unit, 'deg')
+        self.assertEqual(env_var_2.initial_value, 0)
+        self.assertEqual(env_var_2.env_id, 12)
+        self.assertEqual(env_var_2.access_type, 'DUMMY_NODE_VECTOR0')
+        self.assertEqual(env_var_2.access_node, 'Vector__XXX')
+        self.assertEqual(env_var_2.comment, 'Elevation Head')
+        self.assertEqual(
+            repr(env_var_2),
+            "environment_variable('EMC_TrdPower', 1, -180, 400, 'deg', 0, 12,"
+            " 'DUMMY_NODE_VECTOR0', 'Vector__XXX', 'Elevation Head')")
+
 
     def test_foobar(self):
         db = cantools.db.Database()


### PR DESCRIPTION
Implemented a new `environment_variables` _property_ inside `DbcSpecifics` _class_, which contains an ordered dictionary of all environment variables.