### PR TITLE
Separate MUX'd signals in monitor subparser output

### DIFF
--- a/cantools/subparsers/monitor.py
+++ b/cantools/subparsers/monitor.py
@@ -14,6 +14,7 @@ except ImportError:
 import can
 from .. import database
 from .utils import format_message
+from .utils import format_multiplexed_name
 
 
 class QuitError(Exception):
@@ -226,9 +227,14 @@ class Monitor(can.Listener):
             self._discarded += 1
             return
 
+        name = message.name
+        if message.is_multiplexed():
+            name = format_multiplexed_name(message, data, True)
+
         if self._single_line:
             formatted = format_message(message, data, True, True)
-            self._formatted_messages[message.name] = [
+
+            self._formatted_messages[name] = [
                 '{:12.3f} {}'.format(timestamp, formatted)
             ]
         else:
@@ -236,10 +242,10 @@ class Monitor(can.Listener):
             lines = formatted.splitlines()
             formatted = ['{:12.3f}  {}'.format(timestamp, lines[1])]
             formatted += [14 * ' ' + line for line in lines[2:]]
-            self._formatted_messages[message.name] = formatted
+            self._formatted_messages[name] = formatted
 
-        if message.name not in self._filtered_sorted_message_names:
-            self.insort_filtered(message.name)
+        if name not in self._filtered_sorted_message_names:
+            self.insort_filtered(name)
 
     def update_messages(self):
         modified = False

--- a/tests/files/dbc/msxii_system_can.dbc
+++ b/tests/files/dbc/msxii_system_can.dbc
@@ -1,0 +1,104 @@
+VERSION ""
+
+
+NS_ :
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+
+BS_:
+
+BU_: BMS
+
+
+BO_ 1025 BATTERY_VT: 6 BMS
+ SG_ MODULE_TEMP_35 m35 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_34 m34 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_33 m33 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_32 m32 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_31 m31 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_30 m30 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_29 m29 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_28 m28 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_27 m27 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_26 m26 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_25 m25 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_24 m24 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_23 m23 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_22 m22 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_21 m21 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_20 m20 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_19 m19 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_18 m18 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_17 m17 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_16 m16 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_15 m15 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_14 m14 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_13 m13 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_12 m12 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_11 m11 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_10 m10 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_09 m9 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_08 m8 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_07 m7 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_06 m6 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_05 m5 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_04 m4 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_03 m3 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_02 m2 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_01 m1 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_TEMP_00 m0 : 32|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_35 m35 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_34 m34 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_33 m33 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_32 m32 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_31 m31 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_30 m30 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_29 m29 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_28 m28 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_27 m27 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_26 m26 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_25 m25 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_24 m24 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_23 m23 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_22 m22 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_21 m21 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_20 m20 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_19 m19 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_18 m18 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_17 m17 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_16 m16 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_15 m15 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_14 m14 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_13 m13 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_12 m12 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_11 m11 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_10 m10 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_09 m9 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_08 m8 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_07 m7 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_06 m6 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_05 m5 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_04 m4 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_03 m3 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_02 m2 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_01 m1 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ MODULE_VOLTAGE_00 m0 : 16|16@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ BATTERY_VT_INDEX M : 0|16@1+ (1,0) [0|0] "" Vector__XXX

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -114,6 +114,375 @@ IO_DEBUG(
                     actual_output = stdout.getvalue()
                     self.assertEqual(actual_output, expected_output)
 
+    def test_decode_muxed_data(self):
+        argv = [
+            'cantools',
+            'decode',
+            'tests/files/dbc/msxii_system_can.dbc'
+        ]
+
+        input_data = """\
+  vcan0  401   [6]  00 00 98 98 0B 00
+  vcan0  401   [6]  01 00 9C 98 0A 00
+  vcan0  401   [6]  02 00 B5 98 0A 00
+  vcan0  401   [6]  03 00 9D 98 0A 00
+  vcan0  401   [6]  04 00 CB 98 0B 00
+  vcan0  401   [6]  05 00 C5 98 0B 00
+  vcan0  401   [6]  06 00 35 9A EA 59
+  vcan0  401   [6]  07 00 B1 98 FA 59
+  vcan0  401   [6]  08 00 A5 98 0B 00
+  vcan0  401   [6]  09 00 73 99 0C 00
+  vcan0  401   [6]  0A 00 66 98 0B 00
+  vcan0  401   [6]  0B 00 65 96 0B 00
+  vcan0  401   [6]  0C 00 72 99 B3 5A
+  vcan0  401   [6]  0D 00 04 99 9D 5A
+  vcan0  401   [6]  0E 00 F8 9A C4 5A
+  vcan0  401   [6]  0F 00 3B 9C 89 5A
+  vcan0  401   [6]  10 00 8E 9A DE 5A
+  vcan0  401   [6]  11 00 E8 9B DE 5A
+  vcan0  401   [6]  12 00 D5 99 C9 59
+  vcan0  401   [6]  13 00 EE 99 0D 5A
+  vcan0  401   [6]  14 00 83 99 02 5A
+  vcan0  401   [6]  15 00 97 99 12 5A
+  vcan0  401   [6]  16 00 F6 99 0C 5A
+  vcan0  401   [6]  17 00 0E 9B C4 59
+  vcan0  401   [6]  18 00 68 9A 42 5A
+  vcan0  401   [6]  19 00 83 99 22 5A
+  vcan0  401   [6]  1A 00 85 99 3D 5A
+  vcan0  401   [6]  1B 00 EF 99 2F 5A
+  vcan0  401   [6]  1C 00 7E 99 50 5A
+  vcan0  401   [6]  1D 00 39 9A 21 5A
+  vcan0  401   [6]  1E 00 44 99 F9 59
+  vcan0  401   [6]  1F 00 60 99 1B 5A
+  vcan0  401   [6]  20 00 42 99 0A 5A
+  vcan0  401   [6]  21 00 C3 9A 33 5A
+  vcan0  401   [6]  22 00 3D 99 1A 5A
+  vcan0  401   [6]  23 00 59 99 5C 5A
+"""
+
+        expected_output = """\
+  vcan0  401   [6]  00 00 98 98 0B 00 ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 0,
+    MODULE_VOLTAGE_00: 39064,
+    MODULE_TEMP_00: 11
+)
+  vcan0  401   [6]  01 00 9C 98 0A 00 ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 1,
+    MODULE_VOLTAGE_01: 39068,
+    MODULE_TEMP_01: 10
+)
+  vcan0  401   [6]  02 00 B5 98 0A 00 ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 2,
+    MODULE_VOLTAGE_02: 39093,
+    MODULE_TEMP_02: 10
+)
+  vcan0  401   [6]  03 00 9D 98 0A 00 ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 3,
+    MODULE_VOLTAGE_03: 39069,
+    MODULE_TEMP_03: 10
+)
+  vcan0  401   [6]  04 00 CB 98 0B 00 ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 4,
+    MODULE_VOLTAGE_04: 39115,
+    MODULE_TEMP_04: 11
+)
+  vcan0  401   [6]  05 00 C5 98 0B 00 ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 5,
+    MODULE_VOLTAGE_05: 39109,
+    MODULE_TEMP_05: 11
+)
+  vcan0  401   [6]  06 00 35 9A EA 59 ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 6,
+    MODULE_VOLTAGE_06: 39477,
+    MODULE_TEMP_06: 23018
+)
+  vcan0  401   [6]  07 00 B1 98 FA 59 ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 7,
+    MODULE_VOLTAGE_07: 39089,
+    MODULE_TEMP_07: 23034
+)
+  vcan0  401   [6]  08 00 A5 98 0B 00 ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 8,
+    MODULE_VOLTAGE_08: 39077,
+    MODULE_TEMP_08: 11
+)
+  vcan0  401   [6]  09 00 73 99 0C 00 ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 9,
+    MODULE_VOLTAGE_09: 39283,
+    MODULE_TEMP_09: 12
+)
+  vcan0  401   [6]  0A 00 66 98 0B 00 ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 10,
+    MODULE_VOLTAGE_10: 39014,
+    MODULE_TEMP_10: 11
+)
+  vcan0  401   [6]  0B 00 65 96 0B 00 ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 11,
+    MODULE_VOLTAGE_11: 38501,
+    MODULE_TEMP_11: 11
+)
+  vcan0  401   [6]  0C 00 72 99 B3 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 12,
+    MODULE_VOLTAGE_12: 39282,
+    MODULE_TEMP_12: 23219
+)
+  vcan0  401   [6]  0D 00 04 99 9D 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 13,
+    MODULE_VOLTAGE_13: 39172,
+    MODULE_TEMP_13: 23197
+)
+  vcan0  401   [6]  0E 00 F8 9A C4 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 14,
+    MODULE_VOLTAGE_14: 39672,
+    MODULE_TEMP_14: 23236
+)
+  vcan0  401   [6]  0F 00 3B 9C 89 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 15,
+    MODULE_VOLTAGE_15: 39995,
+    MODULE_TEMP_15: 23177
+)
+  vcan0  401   [6]  10 00 8E 9A DE 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 16,
+    MODULE_VOLTAGE_16: 39566,
+    MODULE_TEMP_16: 23262
+)
+  vcan0  401   [6]  11 00 E8 9B DE 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 17,
+    MODULE_VOLTAGE_17: 39912,
+    MODULE_TEMP_17: 23262
+)
+  vcan0  401   [6]  12 00 D5 99 C9 59 ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 18,
+    MODULE_VOLTAGE_18: 39381,
+    MODULE_TEMP_18: 22985
+)
+  vcan0  401   [6]  13 00 EE 99 0D 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 19,
+    MODULE_VOLTAGE_19: 39406,
+    MODULE_TEMP_19: 23053
+)
+  vcan0  401   [6]  14 00 83 99 02 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 20,
+    MODULE_VOLTAGE_20: 39299,
+    MODULE_TEMP_20: 23042
+)
+  vcan0  401   [6]  15 00 97 99 12 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 21,
+    MODULE_VOLTAGE_21: 39319,
+    MODULE_TEMP_21: 23058
+)
+  vcan0  401   [6]  16 00 F6 99 0C 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 22,
+    MODULE_VOLTAGE_22: 39414,
+    MODULE_TEMP_22: 23052
+)
+  vcan0  401   [6]  17 00 0E 9B C4 59 ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 23,
+    MODULE_VOLTAGE_23: 39694,
+    MODULE_TEMP_23: 22980
+)
+  vcan0  401   [6]  18 00 68 9A 42 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 24,
+    MODULE_VOLTAGE_24: 39528,
+    MODULE_TEMP_24: 23106
+)
+  vcan0  401   [6]  19 00 83 99 22 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 25,
+    MODULE_VOLTAGE_25: 39299,
+    MODULE_TEMP_25: 23074
+)
+  vcan0  401   [6]  1A 00 85 99 3D 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 26,
+    MODULE_VOLTAGE_26: 39301,
+    MODULE_TEMP_26: 23101
+)
+  vcan0  401   [6]  1B 00 EF 99 2F 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 27,
+    MODULE_VOLTAGE_27: 39407,
+    MODULE_TEMP_27: 23087
+)
+  vcan0  401   [6]  1C 00 7E 99 50 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 28,
+    MODULE_VOLTAGE_28: 39294,
+    MODULE_TEMP_28: 23120
+)
+  vcan0  401   [6]  1D 00 39 9A 21 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 29,
+    MODULE_VOLTAGE_29: 39481,
+    MODULE_TEMP_29: 23073
+)
+  vcan0  401   [6]  1E 00 44 99 F9 59 ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 30,
+    MODULE_VOLTAGE_30: 39236,
+    MODULE_TEMP_30: 23033
+)
+  vcan0  401   [6]  1F 00 60 99 1B 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 31,
+    MODULE_VOLTAGE_31: 39264,
+    MODULE_TEMP_31: 23067
+)
+  vcan0  401   [6]  20 00 42 99 0A 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 32,
+    MODULE_VOLTAGE_32: 39234,
+    MODULE_TEMP_32: 23050
+)
+  vcan0  401   [6]  21 00 C3 9A 33 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 33,
+    MODULE_VOLTAGE_33: 39619,
+    MODULE_TEMP_33: 23091
+)
+  vcan0  401   [6]  22 00 3D 99 1A 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 34,
+    MODULE_VOLTAGE_34: 39229,
+    MODULE_TEMP_34: 23066
+)
+  vcan0  401   [6]  23 00 59 99 5C 5A ::
+BATTERY_VT(
+    BATTERY_VT_INDEX: 35,
+    MODULE_VOLTAGE_35: 39257,
+    MODULE_TEMP_35: 23132
+)
+"""
+
+        stdout = StringIO()
+
+        with patch('sys.stdin', StringIO(input_data)):
+            with patch('sys.stdout', stdout):
+                with patch('sys.argv', argv):
+                    cantools._main()
+                    actual_output = stdout.getvalue()
+                    self.assertEqual(actual_output, expected_output)
+
+    def test_decode_single_line_muxed_data(self):
+        argv = [
+            'cantools',
+            'decode',
+            '--single-line',
+            'tests/files/dbc/msxii_system_can.dbc'
+        ]
+
+        input_data = """\
+  vcan0  401   [6]  00 00 98 98 0B 00
+  vcan0  401   [6]  01 00 9C 98 0A 00
+  vcan0  401   [6]  02 00 B5 98 0A 00
+  vcan0  401   [6]  03 00 9D 98 0A 00
+  vcan0  401   [6]  04 00 CB 98 0B 00
+  vcan0  401   [6]  05 00 C5 98 0B 00
+  vcan0  401   [6]  06 00 35 9A EA 59
+  vcan0  401   [6]  07 00 B1 98 FA 59
+  vcan0  401   [6]  08 00 A5 98 0B 00
+  vcan0  401   [6]  09 00 73 99 0C 00
+  vcan0  401   [6]  0A 00 66 98 0B 00
+  vcan0  401   [6]  0B 00 65 96 0B 00
+  vcan0  401   [6]  0C 00 72 99 B3 5A
+  vcan0  401   [6]  0D 00 04 99 9D 5A
+  vcan0  401   [6]  0E 00 F8 9A C4 5A
+  vcan0  401   [6]  0F 00 3B 9C 89 5A
+  vcan0  401   [6]  10 00 8E 9A DE 5A
+  vcan0  401   [6]  11 00 E8 9B DE 5A
+  vcan0  401   [6]  12 00 D5 99 C9 59
+  vcan0  401   [6]  13 00 EE 99 0D 5A
+  vcan0  401   [6]  14 00 83 99 02 5A
+  vcan0  401   [6]  15 00 97 99 12 5A
+  vcan0  401   [6]  16 00 F6 99 0C 5A
+  vcan0  401   [6]  17 00 0E 9B C4 59
+  vcan0  401   [6]  18 00 68 9A 42 5A
+  vcan0  401   [6]  19 00 83 99 22 5A
+  vcan0  401   [6]  1A 00 85 99 3D 5A
+  vcan0  401   [6]  1B 00 EF 99 2F 5A
+  vcan0  401   [6]  1C 00 7E 99 50 5A
+  vcan0  401   [6]  1D 00 39 9A 21 5A
+  vcan0  401   [6]  1E 00 44 99 F9 59
+  vcan0  401   [6]  1F 00 60 99 1B 5A
+  vcan0  401   [6]  20 00 42 99 0A 5A
+  vcan0  401   [6]  21 00 C3 9A 33 5A
+  vcan0  401   [6]  22 00 3D 99 1A 5A
+  vcan0  401   [6]  23 00 59 99 5C 5A
+"""
+
+        expected_output = """\
+  vcan0  401   [6]  00 00 98 98 0B 00 :: BATTERY_VT(BATTERY_VT_INDEX: 0, MODULE_VOLTAGE_00: 39064, MODULE_TEMP_00: 11)
+  vcan0  401   [6]  01 00 9C 98 0A 00 :: BATTERY_VT(BATTERY_VT_INDEX: 1, MODULE_VOLTAGE_01: 39068, MODULE_TEMP_01: 10)
+  vcan0  401   [6]  02 00 B5 98 0A 00 :: BATTERY_VT(BATTERY_VT_INDEX: 2, MODULE_VOLTAGE_02: 39093, MODULE_TEMP_02: 10)
+  vcan0  401   [6]  03 00 9D 98 0A 00 :: BATTERY_VT(BATTERY_VT_INDEX: 3, MODULE_VOLTAGE_03: 39069, MODULE_TEMP_03: 10)
+  vcan0  401   [6]  04 00 CB 98 0B 00 :: BATTERY_VT(BATTERY_VT_INDEX: 4, MODULE_VOLTAGE_04: 39115, MODULE_TEMP_04: 11)
+  vcan0  401   [6]  05 00 C5 98 0B 00 :: BATTERY_VT(BATTERY_VT_INDEX: 5, MODULE_VOLTAGE_05: 39109, MODULE_TEMP_05: 11)
+  vcan0  401   [6]  06 00 35 9A EA 59 :: BATTERY_VT(BATTERY_VT_INDEX: 6, MODULE_VOLTAGE_06: 39477, MODULE_TEMP_06: 23018)
+  vcan0  401   [6]  07 00 B1 98 FA 59 :: BATTERY_VT(BATTERY_VT_INDEX: 7, MODULE_VOLTAGE_07: 39089, MODULE_TEMP_07: 23034)
+  vcan0  401   [6]  08 00 A5 98 0B 00 :: BATTERY_VT(BATTERY_VT_INDEX: 8, MODULE_VOLTAGE_08: 39077, MODULE_TEMP_08: 11)
+  vcan0  401   [6]  09 00 73 99 0C 00 :: BATTERY_VT(BATTERY_VT_INDEX: 9, MODULE_VOLTAGE_09: 39283, MODULE_TEMP_09: 12)
+  vcan0  401   [6]  0A 00 66 98 0B 00 :: BATTERY_VT(BATTERY_VT_INDEX: 10, MODULE_VOLTAGE_10: 39014, MODULE_TEMP_10: 11)
+  vcan0  401   [6]  0B 00 65 96 0B 00 :: BATTERY_VT(BATTERY_VT_INDEX: 11, MODULE_VOLTAGE_11: 38501, MODULE_TEMP_11: 11)
+  vcan0  401   [6]  0C 00 72 99 B3 5A :: BATTERY_VT(BATTERY_VT_INDEX: 12, MODULE_VOLTAGE_12: 39282, MODULE_TEMP_12: 23219)
+  vcan0  401   [6]  0D 00 04 99 9D 5A :: BATTERY_VT(BATTERY_VT_INDEX: 13, MODULE_VOLTAGE_13: 39172, MODULE_TEMP_13: 23197)
+  vcan0  401   [6]  0E 00 F8 9A C4 5A :: BATTERY_VT(BATTERY_VT_INDEX: 14, MODULE_VOLTAGE_14: 39672, MODULE_TEMP_14: 23236)
+  vcan0  401   [6]  0F 00 3B 9C 89 5A :: BATTERY_VT(BATTERY_VT_INDEX: 15, MODULE_VOLTAGE_15: 39995, MODULE_TEMP_15: 23177)
+  vcan0  401   [6]  10 00 8E 9A DE 5A :: BATTERY_VT(BATTERY_VT_INDEX: 16, MODULE_VOLTAGE_16: 39566, MODULE_TEMP_16: 23262)
+  vcan0  401   [6]  11 00 E8 9B DE 5A :: BATTERY_VT(BATTERY_VT_INDEX: 17, MODULE_VOLTAGE_17: 39912, MODULE_TEMP_17: 23262)
+  vcan0  401   [6]  12 00 D5 99 C9 59 :: BATTERY_VT(BATTERY_VT_INDEX: 18, MODULE_VOLTAGE_18: 39381, MODULE_TEMP_18: 22985)
+  vcan0  401   [6]  13 00 EE 99 0D 5A :: BATTERY_VT(BATTERY_VT_INDEX: 19, MODULE_VOLTAGE_19: 39406, MODULE_TEMP_19: 23053)
+  vcan0  401   [6]  14 00 83 99 02 5A :: BATTERY_VT(BATTERY_VT_INDEX: 20, MODULE_VOLTAGE_20: 39299, MODULE_TEMP_20: 23042)
+  vcan0  401   [6]  15 00 97 99 12 5A :: BATTERY_VT(BATTERY_VT_INDEX: 21, MODULE_VOLTAGE_21: 39319, MODULE_TEMP_21: 23058)
+  vcan0  401   [6]  16 00 F6 99 0C 5A :: BATTERY_VT(BATTERY_VT_INDEX: 22, MODULE_VOLTAGE_22: 39414, MODULE_TEMP_22: 23052)
+  vcan0  401   [6]  17 00 0E 9B C4 59 :: BATTERY_VT(BATTERY_VT_INDEX: 23, MODULE_VOLTAGE_23: 39694, MODULE_TEMP_23: 22980)
+  vcan0  401   [6]  18 00 68 9A 42 5A :: BATTERY_VT(BATTERY_VT_INDEX: 24, MODULE_VOLTAGE_24: 39528, MODULE_TEMP_24: 23106)
+  vcan0  401   [6]  19 00 83 99 22 5A :: BATTERY_VT(BATTERY_VT_INDEX: 25, MODULE_VOLTAGE_25: 39299, MODULE_TEMP_25: 23074)
+  vcan0  401   [6]  1A 00 85 99 3D 5A :: BATTERY_VT(BATTERY_VT_INDEX: 26, MODULE_VOLTAGE_26: 39301, MODULE_TEMP_26: 23101)
+  vcan0  401   [6]  1B 00 EF 99 2F 5A :: BATTERY_VT(BATTERY_VT_INDEX: 27, MODULE_VOLTAGE_27: 39407, MODULE_TEMP_27: 23087)
+  vcan0  401   [6]  1C 00 7E 99 50 5A :: BATTERY_VT(BATTERY_VT_INDEX: 28, MODULE_VOLTAGE_28: 39294, MODULE_TEMP_28: 23120)
+  vcan0  401   [6]  1D 00 39 9A 21 5A :: BATTERY_VT(BATTERY_VT_INDEX: 29, MODULE_VOLTAGE_29: 39481, MODULE_TEMP_29: 23073)
+  vcan0  401   [6]  1E 00 44 99 F9 59 :: BATTERY_VT(BATTERY_VT_INDEX: 30, MODULE_VOLTAGE_30: 39236, MODULE_TEMP_30: 23033)
+  vcan0  401   [6]  1F 00 60 99 1B 5A :: BATTERY_VT(BATTERY_VT_INDEX: 31, MODULE_VOLTAGE_31: 39264, MODULE_TEMP_31: 23067)
+  vcan0  401   [6]  20 00 42 99 0A 5A :: BATTERY_VT(BATTERY_VT_INDEX: 32, MODULE_VOLTAGE_32: 39234, MODULE_TEMP_32: 23050)
+  vcan0  401   [6]  21 00 C3 9A 33 5A :: BATTERY_VT(BATTERY_VT_INDEX: 33, MODULE_VOLTAGE_33: 39619, MODULE_TEMP_33: 23091)
+  vcan0  401   [6]  22 00 3D 99 1A 5A :: BATTERY_VT(BATTERY_VT_INDEX: 34, MODULE_VOLTAGE_34: 39229, MODULE_TEMP_34: 23066)
+  vcan0  401   [6]  23 00 59 99 5C 5A :: BATTERY_VT(BATTERY_VT_INDEX: 35, MODULE_VOLTAGE_35: 39257, MODULE_TEMP_35: 23132)
+"""
+
+        stdout = StringIO()
+
+        with patch('sys.stdin', StringIO(input_data)):
+            with patch('sys.stdout', stdout):
+                with patch('sys.argv', argv):
+                    cantools._main()
+                    actual_output = stdout.getvalue()
+                    self.assertEqual(actual_output, expected_output)
+
     def test_dump(self):
         argv = [
             'cantools',


### PR DESCRIPTION
Totally forgot I had this patch lying around, after getting caught up
with school again. I cleaned it up, so might as well toss it up for an
initial review.

I'm not sure if this is the right general approach, but I basically
decided that it would be ideal not to modify the `Signal` and `Message`
classes, since this is purely presentation (and those are exposed).

Currently this doesn't affect filtering, which is a plus in my books.
This still displays the message name as the original name, instead of
appending the MUX identifier.