### PR TITLE
Fix deprecation warnings for SocketCAN interfaces in examples

### DIFF
--- a/cantools/tester.py
+++ b/cantools/tester.py
@@ -223,7 +223,7 @@ class Tester(object):
 
     >>> import can
     >>> import cantools
-    >>> can.rc['interface'] = 'socketcan_native'
+    >>> can.rc['interface'] = 'socketcan'
     >>> can.rc['channel'] = 'vcan0'
     >>> can_bus = can.interface.Bus()
     >>> database = cantools.database.load_file('tests/files/tester.kcd')

--- a/examples/motor_tester/main.py
+++ b/examples/motor_tester/main.py
@@ -11,7 +11,7 @@ import can
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 WASHING_MACHINE_KCD_PATH = os.path.join(SCRIPT_DIR, 'system.kcd')
 
-can.rc['interface'] = 'socketcan_native'
+can.rc['interface'] = 'socketcan'
 can.rc['channel'] = 'vcan0'
 
 can_bus = can.interface.Bus()

--- a/examples/motor_tester/motor.py
+++ b/examples/motor_tester/motor.py
@@ -14,7 +14,7 @@ def create_message(speed, load):
 
 
 def main():
-    can.rc['interface'] = 'socketcan_native'
+    can.rc['interface'] = 'socketcan'
     can.rc['channel'] = 'vcan0'
     can_bus = can.interface.Bus()
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='cantools',
       packages=find_packages(exclude=['tests']),
       install_requires=[
           'bitstruct>=6.0.0',
-          'python-can>=2.1.0',
+          'python-can>=2.2.0',
           'textparser>=0.21.1',
           'diskcache'
       ],


### PR DESCRIPTION
The `socketcan_native` and `socketcan_ctypes` interfaces have been
deprecated in `python-can` as of `Version 2.2.0 (2018-06-30)`, and are
superseded by the `socketcan` interface. All the examples have been
updated to updated to use the `socketcan` interface instead.

**Note**: As of `2.2.0`, `python-can` dropped support for Python 3.3, so with
the update in `setup.py`, this implicitly drops support for that as well.