### PR TITLE
Fix test dbc files to include BU_ section

### DIFF
--- a/tests/files/dbc/issue_62.dbc
+++ b/tests/files/dbc/issue_62.dbc
@@ -33,6 +33,8 @@ NS_ :
 
 BS_:
 
+BU_:
+
 BO_ 3221225472 VECTOR__INDEPENDENT_SIG_MSG: 0 Vector__XXX
  SG_ NumberOfMembersInWorkingSet : 0|8@1+ (1,0) [0|0] "" Vector__XXX
  SG_ SourceAddress : 0|8@1+ (1,0) [0|0] "" Vector__XXX

--- a/tests/files/dbc/issue_63.dbc
+++ b/tests/files/dbc/issue_63.dbc
@@ -33,6 +33,8 @@ NS_ :
 
 BS_:
 
+BU_:
+
 BO_ 2566687742 AFT1PSI2: 8 Vector__XXX
  SG_ HtrRes : 40|16@1+ (0.1,0) [0|6425.5] "ohm" Vector__XXX
  SG_ MaxRes : 32|16@1+ (250,0) [0|62500] "kohm" Vector__XXX


### PR DESCRIPTION
BU_ section is mandatory. CANdb++ is not able to open a file without such section.