### PR TITLE
Add float SIG_VALTYPE_ types to DBC string dump

### DIFF
--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -76,6 +76,7 @@ DBC_FMT = (
     '\r\n'
     '\r\n'
     '{cm}\r\n'
+    '{signal_types}'
     '{ba_def}\r\n'
     '{ba_def_def}\r\n'
     '{ba}\r\n'
@@ -526,6 +527,23 @@ def _dump_comments(database):
                                      comment=signal.comment))
 
     return cm
+
+
+def _dump_signal_types(database):
+    valtype = []
+
+    for message in database.messages:
+        for signal in message.signals:
+            if signal.is_float:
+                if signal.length == 32:
+                    float_type = SIGNAL_TYPE_FLOAT
+                elif signal.length == 64:
+                    float_type = SIGNAL_TYPE_DOUBLE
+
+                fmt = 'SIG_VALTYPE_ {} {} : {};'.format(message.frame_id, signal.name, float_type)
+                valtype.append(fmt)
+
+    return valtype
 
 
 def _dump_attribute_definitions(database):
@@ -1259,6 +1277,7 @@ def dump_string(database):
     val_table = _dump_value_tables(database)
     bo = _dump_messages(database)
     cm = _dump_comments(database)
+    signal_types = _dump_signal_types(database)
     ba_def = _dump_attribute_definitions(database)
     ba_def_def = _dump_attribute_definition_defaults(database)
     ba = _dump_attributes(database)
@@ -1269,6 +1288,7 @@ def dump_string(database):
                           val_table='\r\n'.join(val_table),
                           bo='\r\n\r\n'.join(bo),
                           cm='\r\n'.join(cm),
+                          signal_types='\r\n'.join(signal_types),
                           ba_def='\r\n'.join(ba_def),
                           ba_def_def='\r\n'.join(ba_def_def),
                           ba='\r\n'.join(ba),

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3996,7 +3996,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
             self.assertEqual(str(cm.exception), data.message)
 
     def test_float_dbc(self):
-        db = cantools.database.load_file('tests/files/dbc/floating_point.dbc')
+        filename = 'tests/files/dbc/floating_point.dbc'
+        db = cantools.database.load_file(filename)
 
         # Double.
         message = db.get_message_by_frame_id(1024)
@@ -4028,6 +4029,26 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(encoded, encoded_message)
         decoded = message.decode(encoded)
         self.assertEqual(decoded, decoded_message)
+
+        # Identity function: Ensure that loading from as_dbc_string is the same
+        new_db = cantools.database.load_string(db.as_dbc_string(), database_format='dbc')
+        message = new_db.get_message_by_frame_id(1024)
+        signal = message.get_signal_by_name('Signal1')
+        self.assertEqual(signal.is_float, True)
+        self.assertEqual(signal.length, 64)
+
+        message = new_db.get_message_by_frame_id(1025)
+        signal = message.get_signal_by_name('Signal1')
+        self.assertEqual(signal.is_float, True)
+        self.assertEqual(signal.length, 32)
+        signal = message.get_signal_by_name('Signal2')
+        self.assertEqual(signal.is_float, True)
+        self.assertEqual(signal.length, 32)
+
+        # Assert DBC contents
+        self.assertIn('SIG_VALTYPE_ 1024 Signal1 : 2;', db.as_dbc_string())
+        self.assertIn('SIG_VALTYPE_ 1025 Signal1 : 1;', db.as_dbc_string())
+        self.assertIn('SIG_VALTYPE_ 1025 Signal2 : 1;', db.as_dbc_string())
 
     def test_signed_dbc(self):
         db = cantools.database.load_file('tests/files/dbc/signed.dbc')


### PR DESCRIPTION
Currently the `as_dbc_string` function ignores `float` and `double` signal
attributes that identify a `Signal` as a floating type. As such, when a
DBC containing floating types is loaded and subsequently dumped, we lose
information regarding these floating-point `Signals`.

This fixes `as_dbc_string` to also dump `SIG_VALTYPE_`.