### PR TITLE
Support empty VAL_ entries in dbc-files

### DIFF
--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -266,7 +266,7 @@ class Parser(textparser.Parser):
             'VAL_',
             Optional('NUMBER'),
             'WORD',
-            OneOrMore(Sequence('NUMBER', 'STRING')),
+            ZeroOrMore(Sequence('NUMBER', 'STRING')),
             ';')
 
         value_table = Sequence(
@@ -811,7 +811,6 @@ def _load_environment_variables(tokens, comments):
 
     return environment_variables
 
-
 def _load_choices(tokens):
     choices = defaultdict(dict)
 
@@ -819,12 +818,14 @@ def _load_choices(tokens):
         if len(choice[1]) == 0:
             continue
 
+        od = odict((int(''.join(v[0])), v[1]) for v in choice[3])
+        if len(od) == 0:
+            continue
+
         frame_id = int(choice[1][0])
-        choices[frame_id][choice[2]] = odict(
-            (int(''.join(v[0])), v[1]) for v in choice[3])
+        choices[frame_id][choice[2]] = od
 
     return choices
-
 
 def _load_message_senders(tokens, attributes):
     """Load additional message senders.

--- a/tests/files/dbc/empty_choice.dbc
+++ b/tests/files/dbc/empty_choice.dbc
@@ -1,0 +1,51 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: tx_node
+VAL_TABLE_ example_choice 255 "Not available" 254 "Error" ;
+
+
+BO_ 10 example_message: 3 tx_node
+ SG_ no_choice : 16|8@1- (1,0) [0|0] "" Vector__XXX
+ SG_ empty_choice : 8|8@1- (1,0) [0|0] "" Vector__XXX
+ SG_ non_empty_choice : 0|8@1- (1,0) [0|0] "" Vector__XXX
+
+
+
+BA_DEF_  "BusType" STRING ;
+BA_DEF_DEF_  "BusType" "CAN";
+VAL_ 10 empty_choice ;
+VAL_ 10 non_empty_choice 255 "Not available" 254 "Error" ;
+

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -324,6 +324,12 @@ class CanToolsDatabaseTest(unittest.TestCase):
             else:
                 self.assertEqual(db.as_dbc_string(), fin.read())
 
+    def test_dbc_load_empty_choice(self):
+        filename = 'tests/files/dbc/empty_choice.dbc'
+        db = cantools.database.load_file(filename)
+
+        self.assertEqual(db.messages[0].signals[1].choices == None)
+
     def test_padding_bit_order(self):
         """Encode and decode signals with reversed bit order.
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -328,7 +328,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         filename = 'tests/files/dbc/empty_choice.dbc'
         db = cantools.database.load_file(filename)
 
-        self.assertEqual(db.messages[0].signals[1].choices == None)
+        self.assertEqual(db.messages[0].signals[1].choices, None)
 
     def test_padding_bit_order(self):
         """Encode and decode signals with reversed bit order.


### PR DESCRIPTION
I frequently encounter dbc-files with empty VAL_ entries. That's probably a bug in the tool generating said dbc-files, but other tools for loading and manipulating dbc-files are able to open them correctly. So cantools should too.