### PR TITLE
Fix crash when MUX index is not specified in DBC

### DIFF
--- a/cantools/subparsers/monitor.py
+++ b/cantools/subparsers/monitor.py
@@ -253,7 +253,15 @@ class Monitor(can.Listener):
         name = message.name
 
         if message.is_multiplexed():
-            name = format_multiplexed_name(message, data, True)
+            # Handle the case where a multiplexer index is used that isn't
+            # specified in the DBC file (ie. outside of the range). In this
+            # case, we just discard the message, like we do when the CAN
+            # message ID or length doesn't match what's specified in the DBC.
+            try:
+                name = format_multiplexed_name(message, data, True)
+            except database.DecodeError:
+                self._discarded += 1
+                return
 
         if self._single_line:
             formatted = format_message(message, data, True, True)

--- a/cantools/subparsers/utils.py
+++ b/cantools/subparsers/utils.py
@@ -71,10 +71,7 @@ def format_message(message, data, decode_choices, single_line):
         return _format_message_multi_line(message, formatted_signals)
 
 def format_multiplexed_name(message, data, decode_choices):
-    try:
-        decoded_signals = message.decode(data, decode_choices)
-    except Exception as e:
-        return ' ' + str(e)
+    decoded_signals = message.decode(data, decode_choices)
 
     # The idea here is that we rely on the sorted order of the Signals, and
     # then simply go through each possible Multiplexer and build a composite

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -211,6 +211,49 @@ class CanToolsMonitorTest(unittest.TestCase):
     @patch('curses.init_pair')
     @patch('curses.curs_set')
     @patch('curses.use_default_colors')
+    def test_reject_muxed_data_invalid_mux_index(self,
+                                _use_default_colors,
+                                _curs_set,
+                                _init_pair,
+                                is_term_resized,
+                                color_pair,
+                                _bus,
+                                _notifier):
+        # Prepare mocks.
+        stdscr = StdScr()
+        args = Args('tests/files/dbc/msxii_system_can.dbc')
+        color_pair.side_effect = ['green', 'cyan']
+        is_term_resized.return_value = False
+
+        # Run monitor.
+        monitor = Monitor(stdscr, args)
+        monitor.on_message_received(can.Message(
+            arbitration_id=1025,
+            data=b'\x24\x00\x98\x98\x0b\x00'))
+        monitor.run()
+
+        # Check mocks.
+        self.assert_called(
+            stdscr.addstr,
+            [
+                call(0, 0, 'Received: 1, Discarded: 1, Errors: 0'),
+                call(1,
+                     0,
+                     '   TIMESTAMP  MESSAGE                                           ',
+                     'green'),
+                call(29,
+                     0,
+                     'q: Quit, f: Filter, p: Play/Pause, r: Reset                     ',
+                     'cyan')
+            ])
+
+    @patch('can.Notifier')
+    @patch('can.Bus')
+    @patch('curses.color_pair')
+    @patch('curses.is_term_resized')
+    @patch('curses.init_pair')
+    @patch('curses.curs_set')
+    @patch('curses.use_default_colors')
     def test_display_muxed_data(self,
                                 _use_default_colors,
                                 _curs_set,


### PR DESCRIPTION
Fix a crash when the MUX index is not specified inside the DBC file. In
this case, we previously would crash with the following error:

    IndexError: list index out of range

This would happen because the MUX decoding would fail and raise an error
when an invalid MUX index was passed, but the DecodeError would be
caught and then serialized into a string, leading to the IndexError
when the code later attempted to index into it.

This change propagates the error to the monitor subparser's update
function. Here, we handle the invalid MUX index the same way as if we
received an unexpected CAN message that wasn't specified in the DBC, and
discard the message.