### PR TITLE
Remove redundant casts

### DIFF
--- a/cantools/database/can/c_source.py
+++ b/cantools/database/can/c_source.py
@@ -395,7 +395,7 @@ static inline uint8_t pack_left_shift_u{length}(
     uint8_t shift,
     uint8_t mask)
 {{
-    return (uint8_t)((uint8_t)(value << shift) & mask);
+    return (uint8_t)(value << shift) & mask;
 }}
 '''
 
@@ -405,7 +405,7 @@ static inline uint8_t pack_right_shift_u{length}(
     uint8_t shift,
     uint8_t mask)
 {{
-    return (uint8_t)((uint8_t)(value >> shift) & mask);
+    return (uint8_t)(value >> shift) & mask;
 }}
 '''
 
@@ -415,7 +415,7 @@ static inline {var_type} unpack_left_shift_u{length}(
     uint8_t shift,
     uint8_t mask)
 {{
-    return ({var_type})(({var_type})(value & mask) << shift);
+    return ({var_type})(value & mask) << shift;
 }}
 '''
 
@@ -425,7 +425,7 @@ static inline {var_type} unpack_right_shift_u{length}(
     uint8_t shift,
     uint8_t mask)
 {{
-    return ({var_type})(({var_type})(value & mask) >> shift);
+    return ({var_type})(value & mask) >> shift;
 }}
 '''
 


### PR DESCRIPTION
These casts were leading to some compiler warnings. An analysis of the code alongside the C standard (http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf) and rules of operator precedence (https://en.cppreference.com/w/c/language/operator_precedence) shows why they're redundant. Of relevance are sections 6.5.7, 6.5.10, and 6.3.1.1.

In detail, for pack_left_shift_u: due to precedence, (value << shift) will execute first, and shift will be promoted to {var_type}. Then, again due to precedence, the result gets cast to a uint8_t before the bitwise and operation. And then a bitwise and between a uint8_t and a uint8_t just returns a uint8_t with no need for further casting.

For the unpack methods, again the parentheses get executed first, returning a uint8_t, which is first converted to a var_type before the bitshift, and then shift is promoted to var_type to perform the bitshift operation, returning a var_type.