### PR TITLE
Bugfix for dumping dbc with objects whose names have been shortened

### DIFF
--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -1385,6 +1385,11 @@ def make_node_names_unique(database):
     for node in database.nodes:
         name = converter.convert(node.name)
 
+        try:
+            node.dbc.attributes.pop('SystemNodeLongSymbol')
+        except (KeyError, AttributeError):
+            pass
+
         if name is None:
             continue
 
@@ -1413,6 +1418,11 @@ def make_message_names_unique(database):
     for message in database.messages:
         name = converter.convert(message.name)
 
+        try:
+            message.dbc.attributes.pop('SystemMessageLongSymbol')
+        except (KeyError, AttributeError):
+            pass
+
         if name is None:
             continue
 
@@ -1431,6 +1441,11 @@ def make_signal_names_unique(database):
     for message in database.messages:
         for signal in message.signals:
             name = converter.convert(signal.name)
+
+            try:
+                signal.dbc.attributes.pop('SystemSignalLongSymbol')
+            except (KeyError, AttributeError):
+                pass
 
             if name is None:
                 continue

--- a/tests/files/dbc/mod_name_len_dest.dbc
+++ b/tests/files/dbc/mod_name_len_dest.dbc
@@ -1,0 +1,54 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: node_now_short
+
+
+BO_ 1 msg_now_short: 8 node_now_short
+ SG_ sig_now_short : 1|8@1+ (1,0) [0|0] "" Vector__XXX
+
+
+
+
+CM_ BU_ node_now_short "";
+BA_DEF_ BU_  "SystemNodeLongSymbol" STRING ;
+BA_DEF_ BO_  "SystemMessageLongSymbol" STRING ;
+BA_DEF_ SG_  "SystemSignalLongSymbol" STRING ;
+BA_DEF_DEF_  "SystemNodeLongSymbol" "";
+BA_DEF_DEF_  "SystemMessageLongSymbol" "";
+BA_DEF_DEF_  "SystemSignalLongSymbol" "";
+
+
+

--- a/tests/files/dbc/mod_name_len_src.dbc
+++ b/tests/files/dbc/mod_name_len_src.dbc
@@ -1,0 +1,56 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: Node_will_be_shortened_456789_12
+
+
+BO_ 1 Msg_will_be_shortened_3456789_12: 8 Node_will_be_shortened_456789_12
+ SG_ Sig_will_be_shortened_3456789_12 : 1|8@1+ (1,0) [0|0] "" Vector__XXX
+
+
+
+
+CM_ BU_ Node_will_be_shortened_456789_12 "";
+BA_DEF_ BU_  "SystemNodeLongSymbol" STRING ;
+BA_DEF_ BO_  "SystemMessageLongSymbol" STRING ;
+BA_DEF_ SG_  "SystemSignalLongSymbol" STRING ;
+BA_DEF_DEF_  "SystemNodeLongSymbol" "";
+BA_DEF_DEF_  "SystemMessageLongSymbol" "";
+BA_DEF_DEF_  "SystemSignalLongSymbol" "";
+BA_ "SystemNodeLongSymbol" BU_ Node_will_be_shortened_456789_12 "Node_will_be_shortened_456789_12ZZZZ";
+BA_ "SystemMessageLongSymbol" BO_ 1 "Msg_will_be_shortened_3456789_12YYYY";
+BA_ "SystemSignalLongSymbol" SG_ 1 Sig_will_be_shortened_3456789_12 "Sig_will_be_shortened_3456789_12XXXX";
+
+

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4755,10 +4755,11 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         with open(filename_dest, 'rb') as fin:
             if sys.version_info[0] > 2:
-                self.assertEqual(db.as_dbc_string().encode('cp1252'),
-                                 fin.read())
+                self.assertEqual(db.as_dbc_string().encode('cp1252').replace(b'\r', b''),
+                                 fin.read().replace(b'\r', b''))
             else:
-                self.assertEqual(db.as_dbc_string(), fin.read())
+                self.assertEqual(db.as_dbc_string().replace(b'\r', b''),
+                                 fin.read().replace(b'\r', b''))
 
 
 # This file is not '__main__' when executed via 'python setup.py3

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4733,6 +4733,33 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertTrue(db.as_dbc_string().startswith('VERSION "{}"'.
                         format(my_version)))
 
+    def test_shorten_long_names_bugfix(self):
+        """Test if modified object names are dumped correctly to dbc.
+        (Names with original length >32 and new length <= 32 chars)
+
+        """
+
+        filename_src = 'tests/files/dbc/mod_name_len_src.dbc'
+        filename_dest = 'tests/files/dbc/mod_name_len_dest.dbc'
+        db = cantools.database.load_file(filename_src)
+
+        # Now change the names (to <= 32 chars), dump and readback again:
+        msg_name_short = 'msg_now_short'
+        sig_name_short = 'sig_now_short'
+        node_name_short = 'node_now_short'
+        db.messages[0].name = msg_name_short
+        db.messages[0].signals[0].name = sig_name_short
+        db.messages[0].senders[0] = node_name_short
+        db.nodes[0].name = node_name_short
+        db.refresh()
+
+        with open(filename_dest, 'rb') as fin:
+            if sys.version_info[0] > 2:
+                self.assertEqual(db.as_dbc_string().encode('cp1252'),
+                                 fin.read())
+            else:
+                self.assertEqual(db.as_dbc_string(), fin.read())
+
 
 # This file is not '__main__' when executed via 'python setup.py3
 # test'.


### PR DESCRIPTION
Objects (messages, signals, nodes) with an original name >32 chars and a modified name <= 32 chars are now dumped correctly.