### PR TITLE
make it work with AUTOSAR 3 ARXML files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ About
 
 CAN BUS tools in Python 3.
 
-- `DBC`_, `KCD`_, SYM, ARXML 4 and CDD file parsing.
+- `DBC`_, `KCD`_, SYM, ARXML 3&4 and CDD file parsing.
 
 - CAN message encoding and decoding.
 

--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -1003,7 +1003,7 @@ def load_string(string, strict=True):
     # if no known AUTOSAR version was found, blurb
     if autosar_version is None:
         raise ValueError('Root tag "{}" does not correspond to any recognized AUTOSAR namespace.'
-                         .format(ROOT_TAG))
+                         .format(root.tag))
 
     if is_ecu_extract(root):
         return EcuExtractLoader(root, strict).load()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4430,8 +4430,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         self.assertEqual(
             str(cm.exception),
-            'ARXML: "Expected root element tag {http://autosar.org/schema/r4.0}'
-            'AUTOSAR, but got {http://autosar.org/schema/r4.0}NOT-AUTOSAR."')
+            'ARXML: "Root tag "{http://autosar.org/schema/r4.0}NOT-AUTOSAR" does'
+            ' not correspond to any recognized AUTOSAR namespace."')
 
     def test_ecu_extract_arxml(self):
         db = cantools.database.Database()


### PR DESCRIPTION
This patch implements support for the AUTOSAR 3 CAN bus specification. (This is the format used for older models within our company.) While I cannot guarantee that the spec is 100% satisfied, it seems work fine for the files which are floating around internally here.

---

For formal reasons, the following legalese needs to be included (sorry for that):

The changes contained in this pull request are contributed under the terms of the MIT License by Andreas Lauser <Andreas.Lauser@daimler.com>, Daimler AG acting on behalf of MBition GmbH.

https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md

The program was tested solely for our own use cases, which might differ from yours.

Daimler AG
Mercedesstraße 137
70327 Stuttgart, Germany
Phone.: +49711170
E-Mail: dialog@daimler.com

Sitz und Registergericht/Domicile and Court of Registry: Stuttgart, HRB-Nr./Commercial Register No.: 19360
Vorstand/Board of Management: Ola Källenius (Chairman), Martin Daum, Renata Jungo Brüngger, Wilfried Porth, Markus Schäfer, Britta Seeger, Hubertus Troska, Harald Wilhelm
Vorsitzender des Aufsichtsrats/Chairman of the Supervisory Board: Manfred Bischoff

https://www.daimler.com/provider/

