### PR TITLE
fix SIG_VALTYPE_ item on DBC dump for extended frame id messages

### DIFF
--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -591,7 +591,7 @@ def _dump_signal_types(database):
 
             valtype.append(
                 'SIG_VALTYPE_ {} {} : {};'.format(
-                    message.frame_id,
+                    get_dbc_frame_id(message),
                     signal.name,
                     FLOAT_LENGTH_TO_SIGNAL_TYPE[signal.length]))
 


### PR DESCRIPTION
The frame id in the SIG_VALTYPE_ value is wrong when writing the dbc as string if extended frame is valid