### PR TITLE
Fix out of range signal initialization (#183)

### DIFF
--- a/cantools/tester.py
+++ b/cantools/tester.py
@@ -91,7 +91,7 @@ class Message(UserDict, object):
         self.enabled = True
         self._can_message = None
         self._periodic_task = None
-        self.update({signal.name: 0 for signal in database.signals})
+        self.update(self._prepare_initial_signal_values())
 
     @property
     def periodic(self):
@@ -205,6 +205,20 @@ class Message(UserDict, object):
 
         if self._periodic_task is not None:
             self._periodic_task.modify_data(self._can_message)
+
+    def _prepare_initial_signal_values(self):
+        initial_sig_values = dict()
+        for signal in self.database.signals:
+            if signal.initial:
+                # use initial signal value (if set)
+                initial_sig_values[signal.name] = signal.initial
+            elif signal.minimum <= 0 <= signal.maximum:
+                # use 0 if in allowed range
+                initial_sig_values[signal.name] = signal.initial
+            else:
+                # set at least some default value
+                initial_sig_values[signal.name] = signal.minimum
+        return initial_sig_values
 
 
 class Tester(object):

--- a/cantools/tester.py
+++ b/cantools/tester.py
@@ -209,15 +209,17 @@ class Message(UserDict, object):
     def _prepare_initial_signal_values(self):
         initial_sig_values = dict()
         for signal in self.database.signals:
+            minimum = 0 if not signal.minimum else signal.minimum
+            maximum = 0 if not signal.maximum else signal.maximum
             if signal.initial:
                 # use initial signal value (if set)
                 initial_sig_values[signal.name] = signal.initial
-            elif signal.minimum <= 0 <= signal.maximum:
+            elif minimum <= 0 <= maximum:
                 # use 0 if in allowed range
-                initial_sig_values[signal.name] = signal.initial
+                initial_sig_values[signal.name] = 0
             else:
                 # set at least some default value
-                initial_sig_values[signal.name] = signal.minimum
+                initial_sig_values[signal.name] = minimum
         return initial_sig_values
 
 


### PR DESCRIPTION
This PR should resolve the issue #183 

I've introduced a new method which initializes the signals with their "initial values". If this is not set I am checking if 0 is in the signals valid range. If this is also not given, I am setting the value to the signals minimum value.

I am not exactly sure if the minimum value in the last case is the best solution. Please let me know if you have any other suggestions.