### PR TITLE
Added missing cdd parser data object element path

### DIFF
--- a/cantools/database/diagnostics/formats/cdd.py
+++ b/cantools/database/diagnostics/formats/cdd.py
@@ -158,6 +158,7 @@ def _load_did_element(did, data_types):
     offset = 0
     datas = []
     data_objs = did.findall('SIMPLECOMPCONT/DATAOBJ')
+    data_objs += did.findall('SIMPLECOMPCONT/STRUCT/DATAOBJ')
     data_objs += did.findall('SIMPLECOMPCONT/UNION/STRUCT/DATAOBJ')
 
     for data_obj in data_objs:


### PR DESCRIPTION
While importing some CDD files, data elements are missing. Examining the CDD file content, there is an element path that is not considered in cdd.py. This PR adds the missing element path.