### PR TITLE
Fix: comment handling for database in dbc format

### DIFF
--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -861,6 +861,7 @@ def _load_comments(tokens):
     for comment in tokens.get('CM_', []):
         if not isinstance(comment[1], list):
             comments['database']['bus'] = comment[1]
+            continue
 
         item = comment[1]
         kind = item[0]
@@ -1482,7 +1483,7 @@ def _load_bus(attributes, comments):
     except KeyError:
         bus_comment = None
 
-    return Bus(bus_name, baudrate=bus_baudrate, comment = bus_comment)
+    return Bus(bus_name, baudrate=bus_baudrate, comment=bus_comment)
 
 
 def _load_nodes(tokens, comments, attributes, definitions):

--- a/tests/files/dbc/bus_comment.dbc
+++ b/tests/files/dbc/bus_comment.dbc
@@ -1,0 +1,105 @@
+VERSION "2.0"
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: FOO BAR FIE FUM
+VAL_TABLE_ State 1 "Enabled" 0 "Disabled" ;
+
+
+BO_ 2147558192 Foo: 8 FOO
+ SG_ Foo : 0|12@0- (0.01,250) [229.53|270.47] "degK"  BAR
+ SG_ Bar : 24|32@0- (0.1,0) [0|5] "m"  FOO
+
+BO_ 2147558193 Fum: 5 FOO
+ SG_ Fum : 0|12@1- (1,0) [0|10] ""  BAR
+ SG_ Fam : 12|12@1- (1,0) [0|8] ""  BAR
+
+BO_ 2147558194 Bar: 4 FOO
+ SG_ Binary32 : 0|32@1- (1,0) [0|0] ""  FUM
+
+BO_ 2147558195 CanFd: 64 FOO
+ SG_ Fie : 0|64@1+ (1,0) [0|0] ""  FUM
+ SG_ Fas : 64|64@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 780 FOOBAR: 8 FIE
+ SG_ ACC_02_CRC : 0|12@1- (1,0) [0|1] ""  BAR
+
+BO_TX_BU_ 2147558194 : FOO,BAR;
+
+
+CM_ "SpecialRelease";
+CM_ BU_ BAR "fam \"1\"";
+CM_ BO_ 2147558192 "Foo.";
+CM_ SG_ 2147558192 Bar "Bar.";
+BA_DEF_  "DBName" STRING ;
+BA_DEF_  "Baudrate" INT 0 1000000;
+BA_DEF_  "AFloat" FLOAT 0 100;
+BA_DEF_  "BusType" STRING ;
+BA_DEF_ BU_  "FOO" INT 0 100;
+BA_DEF_ BU_  "BAR" STRING ;
+BA_DEF_ BO_  "VFrameFormat" ENUM  "StandardCAN","ExtendedCAN","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","StandardCAN_FD","ExtendedCAN_FD";
+BA_DEF_ BO_  "GenMsgStartValue" STRING ;
+BA_DEF_ BO_  "GenMsgCycleTime" INT 0 1000;
+BA_DEF_REL_ BU_SG_REL_  "AFloat2" FLOAT 0 65535;
+BA_DEF_REL_ BU_SG_REL_  "GenSigTimeoutTime" INT 0 65535;
+BA_DEF_DEF_  "DBName" "";
+BA_DEF_DEF_  "Baudrate" 125000;
+BA_DEF_DEF_  "AFloat" 0;
+BA_DEF_DEF_  "BusType" "";
+BA_DEF_DEF_  "FOO" 0;
+BA_DEF_DEF_  "BAR" "";
+BA_DEF_DEF_  "VFrameFormat" "ExtendedCAN_FD";
+BA_DEF_DEF_  "GenMsgStartValue" "";
+BA_DEF_DEF_  "GenMsgCycleTime" 100;
+BA_DEF_DEF_REL_ "AFloat2" 0;
+BA_DEF_DEF_REL_ "GenSigTimeoutTime" 0;
+BA_ "BusType" "CAN FD";
+BA_ "AFloat" 33.5;
+BA_ "Baudrate" 125000;
+BA_ "DBName" "TheBusName";
+BA_ "FOO" BU_ FIE 1;
+BA_ "BAR" BU_ FIE "FUM";
+BA_ "VFrameFormat" BO_ 2147558192 1;
+BA_ "GenMsgCycleTime" BO_ 2147558193 1;
+BA_ "VFrameFormat" BO_ 2147558193 1;
+BA_ "VFrameFormat" BO_ 2147558194 1;
+BA_ "VFrameFormat" BO_ 2147558195 15;
+BA_ "VFrameFormat" BO_ 780 0;
+BA_REL_ "AFloat2" BU_SG_REL_ FOO SG_ 2147558192 Bar 500;
+BA_REL_ "GenSigTimeoutTime" BU_SG_REL_ FOO SG_ 2147558192 Bar 200;
+VAL_ 2147558193 Fam 1 "Enabled" 0 "Disabled" ;
+SIG_GROUP_ 2147558193 SigGroupName 1 : Fam Fum;
+SIG_VALTYPE_ 2147558192 Bar : 1;
+SIG_VALTYPE_ 2147558194 Binary32 : 1;
+

--- a/tests/files/dbc/bus_comment.dbc
+++ b/tests/files/dbc/bus_comment.dbc
@@ -1,4 +1,4 @@
-VERSION "2.0"
+VERSION ""
 
 
 NS_ : 
@@ -33,73 +33,58 @@ NS_ :
 
 BS_:
 
-BU_: FOO BAR FIE FUM
-VAL_TABLE_ State 1 "Enabled" 0 "Disabled" ;
+BU_: 
 
 
-BO_ 2147558192 Foo: 8 FOO
- SG_ Foo : 0|12@0- (0.01,250) [229.53|270.47] "degK"  BAR
- SG_ Bar : 24|32@0- (0.1,0) [0|5] "m"  FOO
+BO_ 2148676694 Message1: 8 Vector__XXX
+ SG_ BIT_F m24 : 39|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ BIT_H m24 : 38|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ BIT_B m24 : 33|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ BIT_D m24 : 32|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ BIT_E m24 : 29|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ BIT_K m24 : 28|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ BIT_A m24 : 26|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ BIT_L m8 : 24|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ BIT_G m8 : 23|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ BIT_C m8 : 19|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ BIT_J m8 : 18|1@1+ (1,0) [0|0] "" Vector__XXX
+ SG_ Multiplexor M : 2|6@1+ (1,0) [0|0] "" Vector__XXX
 
-BO_ 2147558193 Fum: 5 FOO
- SG_ Fum : 0|12@1- (1,0) [0|10] ""  BAR
- SG_ Fam : 12|12@1- (1,0) [0|8] ""  BAR
 
-BO_ 2147558194 Bar: 4 FOO
- SG_ Binary32 : 0|32@1- (1,0) [0|0] ""  FUM
-
-BO_ 2147558195 CanFd: 64 FOO
- SG_ Fie : 0|64@1+ (1,0) [0|0] ""  FUM
- SG_ Fas : 64|64@1+ (1,0) [0|0] "" Vector__XXX
-
-BO_ 780 FOOBAR: 8 FIE
- SG_ ACC_02_CRC : 0|12@1- (1,0) [0|1] ""  BAR
-
-BO_TX_BU_ 2147558194 : FOO,BAR;
 
 
 CM_ "SpecialRelease";
-CM_ BU_ BAR "fam \"1\"";
-CM_ BO_ 2147558192 "Foo.";
-CM_ SG_ 2147558192 Bar "Bar.";
+CM_ SG_ 2148676694 Multiplexor "Defines data content for response messages.";
+BA_DEF_ BO_  "VFrameFormat" ENUM  "StandardCAN","ExtendedCAN","reserved","J1939PG";
+BA_DEF_ SG_  "GenSigSendType" ENUM  "Cyclic","OnWrite","OnWriteWithRepetition","OnChange","OnChangeWithRepetition","IfActive","IfActiveWithRepetition","NoSigSendType";
+BA_DEF_ SG_  "GenSigInactiveValue" INT 0 0;
+BA_DEF_ BO_  "GenMsgCycleTime" INT 0 0;
+BA_DEF_ BO_  "GenMsgSendType" ENUM  "Cyclic","not_used","not_used","not_used","not_used","Cyclic","not_used","IfActive","NoMsgSendType";
+BA_DEF_ BU_  "NmStationAddress" HEX 0 0;
 BA_DEF_  "DBName" STRING ;
-BA_DEF_  "Baudrate" INT 0 1000000;
-BA_DEF_  "AFloat" FLOAT 0 100;
 BA_DEF_  "BusType" STRING ;
-BA_DEF_ BU_  "FOO" INT 0 100;
-BA_DEF_ BU_  "BAR" STRING ;
-BA_DEF_ BO_  "VFrameFormat" ENUM  "StandardCAN","ExtendedCAN","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","StandardCAN_FD","ExtendedCAN_FD";
-BA_DEF_ BO_  "GenMsgStartValue" STRING ;
-BA_DEF_ BO_  "GenMsgCycleTime" INT 0 1000;
-BA_DEF_REL_ BU_SG_REL_  "AFloat2" FLOAT 0 65535;
-BA_DEF_REL_ BU_SG_REL_  "GenSigTimeoutTime" INT 0 65535;
+BA_DEF_DEF_  "VFrameFormat" "J1939PG";
+BA_DEF_DEF_  "GenSigSendType" "Cyclic";
+BA_DEF_DEF_  "GenSigInactiveValue" 0;
+BA_DEF_DEF_  "GenMsgCycleTime" 0;
+BA_DEF_DEF_  "GenMsgSendType" "NoMsgSendType";
+BA_DEF_DEF_  "NmStationAddress" 0;
 BA_DEF_DEF_  "DBName" "";
-BA_DEF_DEF_  "Baudrate" 125000;
-BA_DEF_DEF_  "AFloat" 0;
-BA_DEF_DEF_  "BusType" "";
-BA_DEF_DEF_  "FOO" 0;
-BA_DEF_DEF_  "BAR" "";
-BA_DEF_DEF_  "VFrameFormat" "ExtendedCAN_FD";
-BA_DEF_DEF_  "GenMsgStartValue" "";
-BA_DEF_DEF_  "GenMsgCycleTime" 100;
-BA_DEF_DEF_REL_ "AFloat2" 0;
-BA_DEF_DEF_REL_ "GenSigTimeoutTime" 0;
-BA_ "BusType" "CAN FD";
-BA_ "AFloat" 33.5;
-BA_ "Baudrate" 125000;
-BA_ "DBName" "TheBusName";
-BA_ "FOO" BU_ FIE 1;
-BA_ "BAR" BU_ FIE "FUM";
-BA_ "VFrameFormat" BO_ 2147558192 1;
-BA_ "GenMsgCycleTime" BO_ 2147558193 1;
-BA_ "VFrameFormat" BO_ 2147558193 1;
-BA_ "VFrameFormat" BO_ 2147558194 1;
-BA_ "VFrameFormat" BO_ 2147558195 15;
-BA_ "VFrameFormat" BO_ 780 0;
-BA_REL_ "AFloat2" BU_SG_REL_ FOO SG_ 2147558192 Bar 500;
-BA_REL_ "GenSigTimeoutTime" BU_SG_REL_ FOO SG_ 2147558192 Bar 200;
-VAL_ 2147558193 Fam 1 "Enabled" 0 "Disabled" ;
-SIG_GROUP_ 2147558193 SigGroupName 1 : Fam Fum;
-SIG_VALTYPE_ 2147558192 Bar : 1;
-SIG_VALTYPE_ 2147558194 Binary32 : 1;
+BA_DEF_DEF_  "BusType" "CAN";
+BA_ "BusType" "CAN";
+BA_ "DBName" "Network_A";
+BA_ "VFrameFormat" BO_ 2148676694 3;
 
+
+
+SG_MUL_VAL_ 2148676694 BIT_J Multiplexor 8-8, 16-16, 24-24;
+SG_MUL_VAL_ 2148676694 BIT_C Multiplexor 8-8, 16-16, 24-24;
+SG_MUL_VAL_ 2148676694 BIT_G Multiplexor 8-8, 16-16, 24-24;
+SG_MUL_VAL_ 2148676694 BIT_L Multiplexor 8-8, 16-16, 24-24;
+SG_MUL_VAL_ 2148676694 BIT_A Multiplexor 24-24;
+SG_MUL_VAL_ 2148676694 BIT_K Multiplexor 24-24;
+SG_MUL_VAL_ 2148676694 BIT_E Multiplexor 24-24;
+SG_MUL_VAL_ 2148676694 BIT_D Multiplexor 24-24;
+SG_MUL_VAL_ 2148676694 BIT_B Multiplexor 24-24;
+SG_MUL_VAL_ 2148676694 BIT_H Multiplexor 24-24;
+SG_MUL_VAL_ 2148676694 BIT_F Multiplexor 24-24;

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4956,10 +4956,9 @@ BO_ 123 Message_1: 6 XYY
             message.encode({ **data_max, 'Delta': data_max['Delta']+Decimal('0.001') })
     def test_bus_comment(self):
         filename = 'tests/files/dbc/bus_comment.dbc'
-        db1 = cantools.database.load_file(filename)
-        self.assertEqual(db1.buses[0].comment, 'SpecialRelease')
-        db2 = cantools.database.load_string( db1.as_dbc_string() )
-        self.assertEqual( db2.buses[0].comment, 'SpecialRelease' )
+        db = cantools.database.load_file(filename)
+        self.assertEqual(db.buses[0].comment, 'SpecialRelease')
+        self.assert_dbc_dump(db, filename)
 # This file is not '__main__' when executed via 'python setup.py3
 # test'.
 logging.basicConfig(level=logging.DEBUG)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4954,7 +4954,12 @@ BO_ 123 Message_1: 6 XYY
         # outside of high bound for Delta
         with self.assertRaises(cantools.database.EncodeError):
             message.encode({ **data_max, 'Delta': data_max['Delta']+Decimal('0.001') })
-
+    def test_bus_comment(self):
+        filename = 'tests/files/dbc/bus_comment.dbc'
+        db1 = cantools.database.load_file(filename)
+        self.assertEqual(db1.buses[0].comment, 'SpecialRelease')
+        db2 = cantools.database.load_string( db1.as_dbc_string() )
+        self.assertEqual( db2.buses[0].comment, 'SpecialRelease' )
 # This file is not '__main__' when executed via 'python setup.py3
 # test'.
 logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
Updated dbc.py to handle comment for Bus.
For comment Sequence after CM_ is choice. ex: CM_ "Special Release";

Test:
Added new file bus_comment. added funtion "test_bus_comment" in test_database to read commnet & check.