### PR TITLE
Empty signal groups

### DIFF
--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -319,7 +319,7 @@ class Parser(textparser.Parser):
             'BO_TX_BU_', 'NUMBER', ':', DelimitedList('WORD'), ';')
 
         signal_group = Sequence(
-            'SIG_GROUP_', 'NUMBER', 'WORD', 'NUMBER', ':', OneOrMore('WORD'), ';')
+            'SIG_GROUP_', 'NUMBER', 'WORD', 'NUMBER', ':', ZeroOrMore('WORD'), ';')
 
         return OneOrMoreDict(
             choice(

--- a/tests/files/dbc/issue_228.dbc
+++ b/tests/files/dbc/issue_228.dbc
@@ -1,0 +1,58 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: Tester
+
+
+
+BO_ 1 SGMsg: 8 Vector__XXX
+ SG_ dupsig : 16|8@1- (1,0) [0|0] "" Vector__XXX
+ SG_ SG2 : 8|8@1- (1,0) [0|0] "" Vector__XXX
+ SG_ SG1 : 0|8@1- (1,0) [0|0] "" Vector__XXX
+
+BO_ 0 NormalMsg: 8 Vector__XXX
+ SG_ Sig_2 : 8|8@1- (1,0) [0|0] "" Vector__XXX
+ SG_ Sig_1 : 0|8@1- (1,0) [0|0] "" Vector__XXX
+
+
+
+
+
+BA_DEF_  "BusType" STRING ;
+BA_DEF_DEF_  "BusType" "CAN";
+
+
+SIG_GROUP_ 1 Empty_Signal_Group 1 :;
+

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4821,6 +4821,16 @@ class CanToolsDatabaseTest(unittest.TestCase):
 
         filename = 'tests/files/dbc/sig_groups_out.dbc'
         self.assert_dbc_dump(db, filename)
+        
+    def test_dbc_issue_228_empty_signal_groups(self):
+        filename = 'tests/files/dbc/issue_228.dbc'
+
+        db = cantools.database.load_file(filename)
+        message = db.get_message_by_name('SGMsg')
+        signal_group = message.signal_groups[0]
+        self.assertEqual(signal_group.name, 'Empty_Signal_Group')
+        self.assertEqual(signal_group.repetitions, 1)
+        self.assertEqual(signal_group.signal_names, [])
 
     def test_dbc_issue_199_more_than_11_bits_standard_frame_id(self):
         filename = 'tests/files/dbc/issue_199.dbc'


### PR DESCRIPTION
Fix for issue #228 
Added support for empty signal groups in DBC files with corresponding test 