### PR TITLE
Added support for CAN FD in monitor.py cli tool

### DIFF
--- a/cantools/subparsers/monitor.py
+++ b/cantools/subparsers/monitor.py
@@ -54,6 +54,9 @@ class Monitor(can.Listener):
         if args.bit_rate is not None:
             kwargs['bitrate'] = int(args.bit_rate)
 
+        if args.fd:
+            kwargs['fd'] = True
+
         try:
             return can.Bus(bustype=args.bus_type,
                            channel=args.channel,
@@ -351,6 +354,10 @@ def add_subparser(subparsers):
     monitor_parser.add_argument(
         '-B', '--bit-rate',
         help='Python CAN bus bit rate.')
+    monitor_parser.add_argument(
+        '-f', '--fd',
+        action='store_true',
+        help='Python CAN CAN-FD bus.')
     monitor_parser.add_argument(
         'database',
         help='Database file.')

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -116,6 +116,34 @@ class CanToolsMonitorTest(unittest.TestCase):
     @patch('curses.init_pair')
     @patch('curses.curs_set')
     @patch('curses.use_default_colors')
+    def test_can_fd(self,
+                            use_default_colors,
+                            curs_set,
+                            init_pair,
+                            is_term_resized,
+                            color_pair,
+                            bus,
+                            notifier):
+        # Prepare mocks.
+        stdscr = StdScr()
+        args = Args('tests/files/dbc/motohawk.dbc')
+        args.fd = True
+        is_term_resized.return_value = False
+
+        # Run monitor.
+        monitor = Monitor(stdscr, args)
+        monitor.run()
+
+        # Check mocks.
+        self.assert_called(bus, [call(bustype='socketcan', channel='vcan0', fd=True)])
+
+    @patch('can.Notifier')
+    @patch('can.Bus')
+    @patch('curses.color_pair')
+    @patch('curses.is_term_resized')
+    @patch('curses.init_pair')
+    @patch('curses.curs_set')
+    @patch('curses.use_default_colors')
     def test_display_one_frame(self,
                                _use_default_colors,
                                _curs_set,

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -117,13 +117,13 @@ class CanToolsMonitorTest(unittest.TestCase):
     @patch('curses.curs_set')
     @patch('curses.use_default_colors')
     def test_can_fd(self,
-                            use_default_colors,
-                            curs_set,
-                            init_pair,
-                            is_term_resized,
-                            color_pair,
-                            bus,
-                            notifier):
+                    use_default_colors,
+                    curs_set,
+                    init_pair,
+                    is_term_resized,
+                    color_pair,
+                    bus,
+                    notifier):
         # Prepare mocks.
         stdscr = StdScr()
         args = Args('tests/files/dbc/motohawk.dbc')

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -25,6 +25,7 @@ class Args(object):
         self.no_strict = False
         self.single_line = single_line
         self.bit_rate = None
+        self.fd = False
         self.bus_type = 'socketcan'
         self.channel = 'vcan0'
 


### PR DESCRIPTION
Added a cli flag to `monitor.py` exposing the `fd` boolean argument in python-can's Bus constructor. Enables use of the monitor tool with CAN FD buses, for python-can bus interfaces that support it.