### PR TITLE
ARXML: use the name of the signal as the signal name

### DIFF
--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -279,7 +279,7 @@ class SystemLoader(object):
         i_signal = self.find_i_signal(i_signal_ref.text)
 
         # Name, start position, length and byte order.
-        name = self.load_signal_name(i_signal_to_i_pdu_mapping)
+        name = self.load_signal_name(i_signal)
         start_position = self.load_signal_start_position(
             i_signal_to_i_pdu_mapping)
         length = self.load_signal_length(i_signal)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4268,7 +4268,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_1.bus_name, None)
 
         signal_1 = message_1.signals[0]
-        self.assertEqual(signal_1.name, 'Signal6')
+        self.assertEqual(signal_1.name, 'signal6')
         self.assertEqual(signal_1.start, 0)
         self.assertEqual(signal_1.length, 1)
         self.assertEqual(signal_1.receivers, [])
@@ -4290,7 +4290,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_1.multiplexer_ids, None)
 
         signal_2 = message_1.signals[1]
-        self.assertEqual(signal_2.name, 'Signal1')
+        self.assertEqual(signal_2.name, 'signal1')
         self.assertEqual(signal_2.start, 4)
         self.assertEqual(signal_2.length, 3)
         self.assertEqual(signal_2.receivers, [])
@@ -4312,7 +4312,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_2.multiplexer_ids, None)
 
         signal_3 = message_1.signals[2]
-        self.assertEqual(signal_3.name, 'Signal5')
+        self.assertEqual(signal_3.name, 'signal5')
         self.assertEqual(signal_3.start, 16)
         self.assertEqual(signal_3.length, 32)
         self.assertEqual(signal_3.receivers, [])
@@ -4346,7 +4346,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_2.bus_name, None)
 
         signal_1 = message_2.signals[0]
-        self.assertEqual(signal_1.name, 'Signal3')
+        self.assertEqual(signal_1.name, 'signal3')
         self.assertEqual(signal_1.start, 6)
         self.assertEqual(signal_1.length, 2)
         self.assertEqual(signal_1.receivers, [])
@@ -4368,7 +4368,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_1.multiplexer_ids, None)
 
         signal_2 = message_2.signals[1]
-        self.assertEqual(signal_2.name, 'Signal2')
+        self.assertEqual(signal_2.name, 'signal2')
         self.assertEqual(signal_2.start, 18)
         self.assertEqual(signal_2.length, 11)
         self.assertEqual(signal_2.receivers, [])
@@ -4390,7 +4390,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_2.multiplexer_ids, None)
 
         signal_3 = message_2.signals[2]
-        self.assertEqual(signal_3.name, 'Signal4')
+        self.assertEqual(signal_3.name, 'signal4')
         self.assertEqual(signal_3.start, 30)
         self.assertEqual(signal_3.length, 4)
         self.assertEqual(signal_3.receivers, [])


### PR DESCRIPTION
This is the beginning of a series to replace https://github.com/eerimoq/cantools/pull/185. I am going to split up the improvements to small patches to ease reviewing (and will close #185). I hope, this is OK. The branch containing all the changes which I'd eventually get merged is here: https://github.com/Daimler/cantools/tree/arxml_refactor

Here comes the first (rather simple) of these patches:

Using the name of the `i-signal-to-i-pdu` mapping as the signal name seems to be conceptually wrong, so let's use the name of the `i-signal` instead. (The files I have to work with on a daily basis use garbage names for the `i-signal-to-i-pdu-mapping`s and reasonable ones for the `i-signal`s...)

Andreas Lauser <andreas.lauser@mbition.io>, Mercedes-Benz AG on behalf of [MBition GmbH](https://mbition.io/).

[Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md#mbition-gmbh)