### PR TITLE
Introduce new ARXML traversal functions

### DIFF
--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -19,140 +19,10 @@ NAMESPACES = {'ns': NAMESPACE}
 
 ROOT_TAG = '{{{}}}AUTOSAR'.format(NAMESPACE)
 
-
-def make_xpath(location):
-    return './ns:' + '/ns:'.join(location)
-
-
-# ARXML XPATHs.
-CAN_FRAME_TRIGGERINGS_XPATH = make_xpath([
-    'AR-PACKAGES',
-    'AR-PACKAGE',
-    'ELEMENTS',
-    'CAN-CLUSTER',
-    'CAN-CLUSTER-VARIANTS',
-    'CAN-CLUSTER-CONDITIONAL',
-    'PHYSICAL-CHANNELS',
-    'CAN-PHYSICAL-CHANNEL',
-    'FRAME-TRIGGERINGS',
-    'CAN-FRAME-TRIGGERING'
-])
-FRAME_REF_XPATH = make_xpath(['FRAME-REF'])
-SHORT_NAME_XPATH = make_xpath(['SHORT-NAME'])
-IDENTIFIER_XPATH = make_xpath(['IDENTIFIER'])
-FRAME_LENGTH_XPATH = make_xpath(['FRAME-LENGTH'])
-CAN_ADDRESSING_MODE_XPATH = make_xpath(['CAN-ADDRESSING-MODE'])
-PDU_REF_XPATH = make_xpath([
-    'PDU-TO-FRAME-MAPPINGS',
-    'PDU-TO-FRAME-MAPPING',
-    'PDU-REF'
-])
-I_SIGNAL_TO_I_PDU_MAPPING_XPATH = make_xpath([
-    'I-SIGNAL-TO-PDU-MAPPINGS',
-    'I-SIGNAL-TO-I-PDU-MAPPING'
-])
-TIME_PERIOD_XPATH = make_xpath([
-    'I-PDU-TIMING-SPECIFICATIONS',
-    'I-PDU-TIMING',
-    'TRANSMISSION-MODE-DECLARATION',
-    'TRANSMISSION-MODE-TRUE-TIMING',
-    'CYCLIC-TIMING',
-    'TIME-PERIOD',
-    'VALUE'
-])
-I_SIGNAL_REF_XPATH = make_xpath(['I-SIGNAL-REF'])
-START_POSITION_XPATH = make_xpath(['START-POSITION'])
-LENGTH_XPATH = make_xpath(['LENGTH'])
-PACKING_BYTE_ORDER_XPATH = make_xpath(['PACKING-BYTE-ORDER'])
-DESC_L_2_XPATH = make_xpath(['DESC', 'L-2'])
-SYSTEM_SIGNAL_REF_XPATH = make_xpath(['SYSTEM-SIGNAL-REF'])
-UNIT_REF_XPATH = make_xpath([
-    'PHYSICAL-PROPS',
-    'SW-DATA-DEF-PROPS-VARIANTS',
-    'SW-DATA-DEF-PROPS-CONDITIONAL',
-    'UNIT-REF'
-])
-COMPU_METHOD_REF_XPATH = make_xpath([
-    'PHYSICAL-PROPS',
-    'SW-DATA-DEF-PROPS-VARIANTS',
-    'SW-DATA-DEF-PROPS-CONDITIONAL',
-    'COMPU-METHOD-REF'
-])
-DISPLAY_NAME_XPATH = make_xpath(['DISPLAY-NAME'])
-CATEGORY_XPATH = make_xpath(['CATEGORY'])
-COMPU_NUMERATOR_XPATH = make_xpath([
-    'COMPU-NUMERATOR',
-    'V'
-])
-COMPU_RATIONAL_COEFFS_XPATH = make_xpath([
-    'COMPU-RATIONAL-COEFFS'
-])
-COMPU_DENOMINATOR_XPATH = make_xpath([
-    'COMPU-DENOMINATOR',
-    'V'
-])
-PHYS_LOWER_LIMIT_XPATH = make_xpath([
-    'COMPU-INTERNAL-TO-PHYS',
-    'COMPU-SCALES',
-    'COMPU-SCALE',
-    'LOWER-LIMIT'
-])
-PHYS_UPPER_LIMIT_XPATH = make_xpath([
-    'COMPU-INTERNAL-TO-PHYS',
-    'COMPU-SCALES',
-    'COMPU-SCALE',
-    'UPPER-LIMIT'
-])
-COMPU_SCALE_XPATH = make_xpath([
-    'COMPU-INTERNAL-TO-PHYS',
-    'COMPU-SCALES',
-    'COMPU-SCALE'
-])
-VT_XPATH = make_xpath([
-    'COMPU-CONST',
-    'VT'
-])
-LOWER_LIMIT_XPATH = make_xpath(['LOWER-LIMIT'])
-UPPER_LIMIT_XPATH = make_xpath(['UPPER-LIMIT'])
-BASE_TYPE_ENCODING_XPATH = make_xpath(['BASE-TYPE-ENCODING'])
-BASE_TYPE_REF_XPATH = make_xpath([
-    'NETWORK-REPRESENTATION-PROPS',
-    'SW-DATA-DEF-PROPS-VARIANTS',
-    'SW-DATA-DEF-PROPS-CONDITIONAL',
-    'BASE-TYPE-REF'
-])
-ECUC_VALUE_COLLECTION_XPATH = make_xpath([
-    'AR-PACKAGES',
-    'AR-PACKAGE',
-    'ELEMENTS',
-    'ECUC-VALUE-COLLECTION'
-])
-ECUC_MODULE_CONFIGURATION_VALUES_REF_XPATH = make_xpath([
-    'ECUC-VALUES',
-    'ECUC-MODULE-CONFIGURATION-VALUES-REF-CONDITIONAL',
-    'ECUC-MODULE-CONFIGURATION-VALUES-REF'
-])
-ECUC_REFERENCE_VALUE_XPATH = make_xpath([
-    'REFERENCE-VALUES',
-    'ECUC-REFERENCE-VALUE'
-])
-VALUE_REF_XPATH = make_xpath(['VALUE-REF'])
-PARAMETER_VALUES_XPATH = make_xpath(['PARAMETER-VALUES'])
-DEFINITION_REF_XPATH = make_xpath(['DEFINITION-REF'])
-VALUE_XPATH = make_xpath(['VALUE'])
-REFERENCE_VALUES_XPATH = make_xpath([
-    'REFERENCE-VALUES'
-])
-
-
 class SystemLoader(object):
-
     def __init__(self, root, strict):
         self.root = root
         self.strict = strict
-        self._system_signal_cache = {}
-        self._compu_method_cache = {}
-        self._sw_base_type_cache = {}
         self._arxml_reference_cache = {}
 
     def load(self):
@@ -160,9 +30,23 @@ class SystemLoader(object):
         messages = []
         version = None
 
-        can_frame_triggerings = self.root.iterfind(CAN_FRAME_TRIGGERINGS_XPATH,
-                                                   NAMESPACES)
-
+        # This code inspects the top level packages. Packages in
+        # sub-packages are not treated yet.  This might or might not
+        # be necessary.
+        can_frame_triggerings = \
+            self.get_arxml_children(self.root,
+                                    [
+                                        'AR-PACKAGES',
+                                        '*AR-PACKAGE',
+                                        'ELEMENTS',
+                                        '*&CAN-CLUSTER',
+                                        'CAN-CLUSTER-VARIANTS',
+                                        '*&CAN-CLUSTER-CONDITIONAL',
+                                        'PHYSICAL-CHANNELS',
+                                        '*&CAN-PHYSICAL-CHANNEL',
+                                        'FRAME-TRIGGERINGS',
+                                        '*&CAN-FRAME-TRIGGERING'
+                                    ])
         for can_frame_triggering in can_frame_triggerings:
             messages.append(self.load_message(can_frame_triggering))
 
@@ -180,20 +64,13 @@ class SystemLoader(object):
         cycle_time = None
         senders = []
 
-        frame_ref_xpath = can_frame_triggering.find(FRAME_REF_XPATH,
-                                                    NAMESPACES).text
-        can_frame = self.find_can_frame(frame_ref_xpath)
-
-        if can_frame is None:
-            # dangling reference to the can frame object.
-            raise ValueError(f"Encountered dangling reference FRAME-REF: {frame_ref_xpath}")
+        can_frame = self.get_can_frame(can_frame_triggering)
 
         # Name, frame id, length, is_extended_frame and comment.
         name = self.load_message_name(can_frame)
         frame_id = self.load_message_frame_id(can_frame_triggering)
         length = self.load_message_length(can_frame)
-        is_extended_frame = self.load_message_is_extended_frame(
-            can_frame_triggering)
+        is_extended_frame = self.load_message_is_extended_frame(can_frame_triggering)
         comment = self.load_message_comment(can_frame)
 
         # ToDo: senders
@@ -201,18 +78,33 @@ class SystemLoader(object):
         # Find all signals in this message.
         signals = []
 
-        pdu_ref_xpath = can_frame.find(PDU_REF_XPATH, NAMESPACES).text
-        i_signal_i_pdu = self.find_i_signal_i_pdu(pdu_ref_xpath)
+        # For "sane" bus systems like CAN or LIN, there ought to be
+        # only a single PDU per frame. AUTOSAR also supports "insane"
+        # bus systems like flexray, though...
+        pdu = self.get_pdu(can_frame)
 
-        if i_signal_i_pdu is not None:
-            time_period = i_signal_i_pdu.find(TIME_PERIOD_XPATH, NAMESPACES)
+        if pdu is not None:
+            time_period = \
+                self.get_unique_arxml_child(pdu,
+                                            [
+                                                'I-PDU-TIMING-SPECIFICATIONS',
+                                                'I-PDU-TIMING',
+                                                'TRANSMISSION-MODE-DECLARATION',
+                                                'TRANSMISSION-MODE-TRUE-TIMING',
+                                                'CYCLIC-TIMING',
+                                                'TIME-PERIOD',
+                                                'VALUE'
+                                            ])
 
             if time_period is not None:
                 cycle_time = int(float(time_period.text) * 1000)
 
-            i_signal_to_i_pdu_mappings = i_signal_i_pdu.iterfind(
-                I_SIGNAL_TO_I_PDU_MAPPING_XPATH,
-                NAMESPACES)
+            i_signal_to_i_pdu_mappings = \
+                self.get_arxml_children(pdu,
+                                        [
+                                            'I-SIGNAL-TO-PDU-MAPPINGS',
+                                            '*&I-SIGNAL-TO-I-PDU-MAPPING'
+                                        ])
 
             for i_signal_to_i_pdu_mapping in i_signal_to_i_pdu_mappings:
                 signal = self.load_signal(i_signal_to_i_pdu_mapping)
@@ -233,24 +125,29 @@ class SystemLoader(object):
                        strict=self.strict)
 
     def load_message_name(self, can_frame_triggering):
-        return can_frame_triggering.find(SHORT_NAME_XPATH, NAMESPACES).text
+        return self.get_unique_arxml_child(can_frame_triggering,
+                                           "SHORT-NAME").text
 
     def load_message_frame_id(self, can_frame_triggering):
-        return int(can_frame_triggering.find(IDENTIFIER_XPATH,
-                                             NAMESPACES).text)
+        return int(self.get_unique_arxml_child(can_frame_triggering,
+                                                'IDENTIFIER').text)
 
     def load_message_length(self, can_frame):
-        return int(can_frame.find(FRAME_LENGTH_XPATH, NAMESPACES).text)
+        return int(self.get_unique_arxml_child(can_frame,
+                                               'FRAME-LENGTH').text)
 
     def load_message_is_extended_frame(self, can_frame_triggering):
-        can_addressing_mode = can_frame_triggering.find(
-            CAN_ADDRESSING_MODE_XPATH,
-            NAMESPACES).text
+        can_addressing_mode = \
+            self.get_unique_arxml_child(can_frame_triggering,
+                                        'CAN-ADDRESSING-MODE')
 
-        return can_addressing_mode == 'EXTENDED'
+        return False if can_addressing_mode is None \
+                     else can_addressing_mode.text == 'EXTENDED'
 
     def load_message_comment(self, can_frame):
-        l_2 = can_frame.find(DESC_L_2_XPATH, NAMESPACES)
+        # This extracts a single language. Support for multi languages
+        # will be implemented in the near future.
+        l_2 = self.get_unique_arxml_child(can_frame, ['DESC', 'L-2'])
 
         if l_2 is not None:
             return l_2.text
@@ -273,37 +170,27 @@ class SystemLoader(object):
         receivers = []
         decimal = SignalDecimal(Decimal(factor), Decimal(offset))
 
-        i_signal_ref = i_signal_to_i_pdu_mapping.find(
-            I_SIGNAL_REF_XPATH,
-            NAMESPACES)
+        i_signal = self.get_i_signal(i_signal_to_i_pdu_mapping)
 
-        if i_signal_ref is None:
-            # Probably a signal group (I-SIGNAL-GROUP-REF).
+        if i_signal is None:
+            # Probably a signal group (I-SIGNAL-GROUP).
             return None
-
-        i_signal = self.find_i_signal(i_signal_ref.text)
 
         # Name, start position, length and byte order.
         name = self.load_signal_name(i_signal)
-        start_position = self.load_signal_start_position(
-            i_signal_to_i_pdu_mapping)
+        start_position = self.load_signal_start_position(i_signal_to_i_pdu_mapping)
         length = self.load_signal_length(i_signal)
         byte_order = self.load_signal_byte_order(i_signal_to_i_pdu_mapping)
 
-        system_signal_ref = i_signal.find(SYSTEM_SIGNAL_REF_XPATH,
-                                          NAMESPACES)
-
-        if system_signal_ref is not None:
-            system_signal = self.get_system_signal(system_signal_ref.text)
-
+        system_signal = self.get_system_signal(i_signal)
+        if system_signal is not None:
             # Unit and comment.
             unit = self.load_signal_unit(system_signal)
             comment = self.load_signal_comment(system_signal)
 
             # Minimum, maximum, factor, offset and choices.
-            minimum, maximum, factor, offset, choices = self.load_system_signal(
-                system_signal,
-                decimal)
+            minimum, maximum, factor, offset, choices = \
+                self.load_system_signal(system_signal, decimal)
 
         # Type.
         is_signed, is_float = self.load_signal_type(i_signal)
@@ -326,37 +213,43 @@ class SystemLoader(object):
                       is_float=is_float,
                       decimal=decimal)
 
-    def load_signal_name(self, i_signal_to_i_pdu_mapping):
-        return i_signal_to_i_pdu_mapping.find(SHORT_NAME_XPATH,
-                                              NAMESPACES).text
+    def load_signal_name(self, i_signal):
+        return self.get_unique_arxml_child(i_signal,
+                                           "SHORT-NAME").text
 
     def load_signal_start_position(self, i_signal_to_i_pdu_mapping):
-        return int(i_signal_to_i_pdu_mapping.find(
-            START_POSITION_XPATH,
-            NAMESPACES).text)
+        return int(self.get_unique_arxml_child(i_signal_to_i_pdu_mapping,
+                                               'START-POSITION').text)
 
     def load_signal_length(self, i_signal):
-        return int(i_signal.find(LENGTH_XPATH, NAMESPACES).text)
+        return int(self.get_unique_arxml_child(i_signal, 'LENGTH').text)
 
     def load_signal_byte_order(self, i_signal_to_i_pdu_mapping):
-        packing_byte_order = i_signal_to_i_pdu_mapping.find(
-            PACKING_BYTE_ORDER_XPATH,
-            NAMESPACES).text
+        packing_byte_order = \
+            self.get_unique_arxml_child(i_signal_to_i_pdu_mapping,
+                                        'PACKING-BYTE-ORDER')
 
-        if packing_byte_order == 'MOST-SIGNIFICANT-BYTE-FIRST':
+        if packing_byte_order is not None and packing_byte_order.text == 'MOST-SIGNIFICANT-BYTE-FIRST':
             return 'big_endian'
         else:
             return 'little_endian'
 
     def load_signal_unit(self, system_signal):
-        unit_ref = system_signal.find(UNIT_REF_XPATH, NAMESPACES)
+        res = self.get_unique_arxml_child(system_signal,
+                                          [
+                                              'PHYSICAL-PROPS',
+                                              'SW-DATA-DEF-PROPS-VARIANTS',
+                                              '&SW-DATA-DEF-PROPS-CONDITIONAL',
+                                              '&UNIT',
+                                              'DISPLAY-NAME'
+                                          ])
 
-        if unit_ref is not None:
-            return self.find_unit(unit_ref.text).find(DISPLAY_NAME_XPATH,
-                                                      NAMESPACES).text
+        return None if res is None else res.text
 
     def load_signal_comment(self, system_signal):
-        l_2 = system_signal.find(DESC_L_2_XPATH, NAMESPACES)
+        # This extracts a single language. Support for multi languages
+        # will be implemented in the near future.
+        l_2 = self.get_unique_arxml_child(system_signal, ['DESC', 'L-2'])
 
         if l_2 is not None:
             return l_2.text
@@ -382,10 +275,15 @@ class SystemLoader(object):
         maximum = None
         choices = {}
 
-        for compu_scale in compu_method.iterfind(COMPU_SCALE_XPATH, NAMESPACES):
-            lower_limit = compu_scale.find(LOWER_LIMIT_XPATH, NAMESPACES)
-            upper_limit = compu_scale.find(UPPER_LIMIT_XPATH, NAMESPACES)
-            vt = compu_scale.find(VT_XPATH, NAMESPACES)
+        for compu_scale in self.get_arxml_children(compu_method,
+                                                   [
+                                                       '&COMPU-INTERNAL-TO-PHYS',
+                                                       'COMPU-SCALES',
+                                                       '*&COMPU-SCALE'
+                                                   ]):
+            lower_limit = self.get_unique_arxml_child(compu_scale, 'LOWER-LIMIT')
+            upper_limit = self.get_unique_arxml_child(compu_scale, 'UPPER-LIMIT')
+            vt = self.get_unique_arxml_child(compu_scale, [ '&COMPU-CONST', 'VT' ])
 
             if vt is not None:
                 choices[vt.text] = int(lower_limit.text)
@@ -396,24 +294,21 @@ class SystemLoader(object):
         return minimum, maximum, choices
 
     def load_linear_factor_and_offset(self, compu_scale, decimal):
-        compu_rational_coeffs = compu_scale.find(
-            COMPU_RATIONAL_COEFFS_XPATH,
-            NAMESPACES)
+        compu_rational_coeffs = \
+        self.get_unique_arxml_child(compu_scale, '&COMPU-RATIONAL-COEFFS')
 
         if compu_rational_coeffs is None:
             return 1, 0
 
-        numerators = compu_rational_coeffs.findall(COMPU_NUMERATOR_XPATH,
-                                                   NAMESPACES)
-
+        numerators = self.get_arxml_children(compu_rational_coeffs,
+                                             ['&COMPU-NUMERATOR', '*&V'])
         if len(numerators) != 2:
             raise ValueError(
                 'Expected 2 numerator values for linear scaling, but '
                 'got {}.'.format(len(numerators)))
 
-        denominators = compu_rational_coeffs.findall(COMPU_DENOMINATOR_XPATH,
-                                                     NAMESPACES)
-
+        denominators = self.get_arxml_children(compu_rational_coeffs,
+                                               ['&COMPU-DENOMINATOR', '*&V'])
         if len(denominators) != 1:
             raise ValueError(
                 'Expected 1 denominator value for linear scaling, but '
@@ -426,11 +321,15 @@ class SystemLoader(object):
         return float(decimal.scale), float(decimal.offset)
 
     def load_linear(self, compu_method, decimal):
-        compu_scale = compu_method.find(COMPU_SCALE_XPATH,
-                                        NAMESPACES)
+        compu_scale = self.get_unique_arxml_child(compu_method,
+                                                  [
+                                                      'COMPU-INTERNAL-TO-PHYS',
+                                                      'COMPU-SCALES',
+                                                      '&COMPU-SCALE'
+                                                  ])
 
-        lower_limit = compu_scale.find(LOWER_LIMIT_XPATH, NAMESPACES)
-        upper_limit = compu_scale.find(UPPER_LIMIT_XPATH, NAMESPACES)
+        lower_limit = self.get_unique_arxml_child(compu_scale, '&LOWER-LIMIT')
+        upper_limit = self.get_unique_arxml_child(compu_scale, '&UPPER-LIMIT')
 
         minimum = self.load_minimum(lower_limit, decimal)
         maximum = self.load_maximum(upper_limit, decimal)
@@ -448,10 +347,16 @@ class SystemLoader(object):
         offset = 0
         choices = {}
 
-        for compu_scale in compu_method.iterfind(COMPU_SCALE_XPATH, NAMESPACES):
-            lower_limit = compu_scale.find(LOWER_LIMIT_XPATH, NAMESPACES)
-            upper_limit = compu_scale.find(UPPER_LIMIT_XPATH, NAMESPACES)
-            vt = compu_scale.find(VT_XPATH, NAMESPACES)
+        for compu_scale in self.get_arxml_children(compu_method,
+                                                   [
+                                                       '&COMPU-INTERNAL-TO-PHYS',
+                                                       'COMPU-SCALES',
+                                                       '*&COMPU-SCALE'
+                                                   ]):
+
+            lower_limit = self.get_unique_arxml_child(compu_scale, 'LOWER-LIMIT')
+            upper_limit = self.get_unique_arxml_child(compu_scale, 'UPPER-LIMIT')
+            vt = self.get_unique_arxml_child(compu_scale, [ '&COMPU-CONST', 'VT' ])
 
             if vt is not None:
                 choices[vt.text] = int(lower_limit.text)
@@ -471,38 +376,30 @@ class SystemLoader(object):
         offset = 0
         choices = None
 
-        compu_method_ref = system_signal.find(COMPU_METHOD_REF_XPATH,
-                                              NAMESPACES)
+        compu_method = self.get_compu_method(system_signal)
 
-        if compu_method_ref is not None:
-            compu_method = self.get_compu_method(compu_method_ref.text)
-            category = compu_method.find(CATEGORY_XPATH, NAMESPACES)
+        if compu_method is not None:
+            category = self.get_unique_arxml_child(compu_method, 'CATEGORY')
 
             if category is None:
                 raise ValueError(
-                    'CATEGORY in {} does not exist.'.format(
-                        compu_method_ref.text))
+                    'CATEGORY in compu method {} does not exist.'.format(
+                        compu_method.find('SHORT-NAME').text))
 
             category = category.text
 
             if category == 'TEXTTABLE':
-                minimum, maximum, choices = self.load_texttable(
-                    compu_method,
-                    decimal)
+                minimum, maximum, choices = self.load_texttable(compu_method, decimal)
             elif category == 'LINEAR':
-                minimum, maximum, factor, offset = self.load_linear(
-                    compu_method,
-                    decimal)
+                minimum, maximum, factor, offset = self.load_linear(compu_method, decimal)
             elif category == 'SCALE_LINEAR_AND_TEXTTABLE':
                 (minimum,
                  maximum,
                  factor,
                  offset,
-                 choices) = self.load_scale_linear_and_texttable(
-                     compu_method,
-                     decimal)
+                 choices) = self.load_scale_linear_and_texttable(compu_method, decimal)
             else:
-                LOGGER.debug('Category %s is not yet implemented.', category)
+                LOGGER.debug('Compu method category %s is not yet implemented.', category)
 
         return minimum, maximum, factor, offset, choices
 
@@ -511,17 +408,16 @@ class SystemLoader(object):
         is_signed = False
         is_float = False
 
-        base_type_ref = i_signal.find(BASE_TYPE_REF_XPATH, NAMESPACES)
+        base_type = self.get_sw_base_type(i_signal)
 
-        if base_type_ref is not None:
-            sw_base_type = self.get_sw_base_type(base_type_ref.text)
-            base_type_encoding = sw_base_type.find(BASE_TYPE_ENCODING_XPATH,
-                                                   NAMESPACES)
+        if base_type is not None:
+            base_type_encoding = \
+                self.get_unique_arxml_child(base_type, '&BASE-TYPE-ENCODING')
 
             if base_type_encoding is None:
                 raise ValueError(
-                    'BASE-TYPE-ENCODING in {} does not exist.'.format(
-                        base_type_ref.text))
+                    'BASE-TYPE-ENCODING in base type {} does not exist.'.format(
+                        base_type.find('SHORT-NAME').text))
 
             base_type_encoding = base_type_encoding.text
 
@@ -531,24 +427,6 @@ class SystemLoader(object):
                 is_float = True
 
         return is_signed, is_float
-
-    def find(self, child_elem, xpath):
-        short_names = xpath.lstrip('/').split('/')
-        location = []
-
-        for short_name in short_names[:-1]:
-            location += [
-                'AR-PACKAGES',
-                "AR-PACKAGE/[ns:SHORT-NAME='{}']".format(short_name)
-            ]
-
-        location += [
-            'ELEMENTS',
-            "{}/[ns:SHORT-NAME='{}']".format(child_elem,
-                                             short_names[-1])
-        ]
-
-        return self.root.find(make_xpath(location), NAMESPACES)
 
     def follow_arxml_reference(self, base_elem, arxml_path, child_tag_name):
         """Follow a relative or absolute ARXML reference
@@ -666,7 +544,7 @@ class SystemLoader(object):
 
                 if not is_nodeset and len(local_result) > 1:
                     raise ValueError(f'Encountered a a non-unique child node of type {child_tag_name} which ought to be unique')
-                    
+
                 result.extend(local_result)
 
             base_elems = result
@@ -691,66 +569,70 @@ class SystemLoader(object):
         else:
             raise ValueError(f'{child_location} does not resolve into a unique node')
 
-    def find_can_frame(self, xpath):
-        return self.find('CAN-FRAME', xpath)
+    def get_can_frame(self, can_frame_triggering):
+        return self.get_unique_arxml_child(can_frame_triggering, '&FRAME')
 
-    def find_i_signal(self, xpath):
-        return self.find('I-SIGNAL', xpath)
+    def get_i_signal(self, i_signal_to_i_pdu_mapping):
+        return self.get_unique_arxml_child(i_signal_to_i_pdu_mapping,
+                                           'I-SIGNAL')
 
-    def find_i_signal_i_pdu(self, xpath):
-        return self.find('I-SIGNAL-I-PDU', xpath)
+    def get_pdu(self, can_frame):
+        return self.get_unique_arxml_child(can_frame,
+                                           [
+                                               'PDU-TO-FRAME-MAPPINGS',
+                                               '&PDU-TO-FRAME-MAPPING',
+                                               '&PDU'
+                                           ])
 
-    def get_system_signal(self, xpath):
-        if xpath in self._system_signal_cache:
-            system_signal = self._system_signal_cache[xpath]
-        else:
-            system_signal = self.find('SYSTEM-SIGNAL', xpath)
+    def get_system_signal(self, i_signal):
+        return self.get_unique_arxml_child(i_signal, '&SYSTEM-SIGNAL')
 
-            if system_signal is None:
-                raise ValueError(
-                    'SYSTEM-SIGNAL at {} does not exist.'.format(xpath))
+    def get_compu_method(self, system_signal):
+        return self.get_unique_arxml_child(system_signal,
+                                           [
+                                               '&PHYSICAL-PROPS',
+                                               'SW-DATA-DEF-PROPS-VARIANTS',
+                                               '&SW-DATA-DEF-PROPS-CONDITIONAL',
+                                               '&COMPU-METHOD'
+                                           ])
 
-            self._system_signal_cache[xpath] = system_signal
+    def get_sw_base_type(self, i_signal):
+        return self.get_unique_arxml_child(i_signal,
+                                           [
+                                               '&NETWORK-REPRESENTATION-PROPS',
+                                               'SW-DATA-DEF-PROPS-VARIANTS',
+                                               '&SW-DATA-DEF-PROPS-CONDITIONAL',
+                                               '&BASE-TYPE'
+                                           ])
 
-        return system_signal
 
-    def find_unit(self, xpath):
-        unit = self.find('UNIT', xpath)
+def make_xpath(location):
+    return './ns:' + '/ns:'.join(location)
 
-        if unit is None:
-            raise ValueError(
-                'UNIT at {} does not exist.'.format(xpath))
-
-        return unit
-
-    def get_compu_method(self, xpath):
-        if xpath in self._compu_method_cache:
-            compu_method = self._compu_method_cache[xpath]
-        else:
-            compu_method = self.find('COMPU-METHOD', xpath)
-
-            if compu_method is None:
-                raise ValueError(
-                    'COMPU-METHOD at {} does not exist.'.format(xpath))
-
-            self._compu_method_cache[xpath] = compu_method
-
-        return compu_method
-
-    def get_sw_base_type(self, xpath):
-        if xpath in self._sw_base_type_cache:
-            sw_base_type = self._sw_base_type_cache[xpath]
-        else:
-            sw_base_type = self.find('SW-BASE-TYPE', xpath)
-
-            if sw_base_type is None:
-                raise ValueError(
-                    'SW-BASE-TYPE at {} does not exist.'.format(xpath))
-
-            self._sw_base_type_cache[xpath] = sw_base_type
-
-        return sw_base_type
-
+# ARXML XPATHs for the EcuExtractLoader
+ECUC_VALUE_COLLECTION_XPATH = make_xpath([
+    'AR-PACKAGES',
+    'AR-PACKAGE',
+    'ELEMENTS',
+    'ECUC-VALUE-COLLECTION'
+])
+ECUC_MODULE_CONFIGURATION_VALUES_REF_XPATH = make_xpath([
+    'ECUC-VALUES',
+    'ECUC-MODULE-CONFIGURATION-VALUES-REF-CONDITIONAL',
+    'ECUC-MODULE-CONFIGURATION-VALUES-REF'
+])
+ECUC_REFERENCE_VALUE_XPATH = make_xpath([
+    'REFERENCE-VALUES',
+    'ECUC-REFERENCE-VALUE'
+])
+DEFINITION_REF_XPATH = make_xpath(['DEFINITION-REF'])
+VALUE_XPATH = make_xpath(['VALUE'])
+VALUE_REF_XPATH = make_xpath(['VALUE-REF'])
+SHORT_NAME_XPATH = make_xpath(['SHORT-NAME'])
+PARAMETER_VALUES_XPATH = make_xpath(['PARAMETER-VALUES'])
+REFERENCE_VALUES_XPATH = make_xpath([
+    'REFERENCE-VALUES'
+])
 
 class EcuExtractLoader(object):
 

--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -153,6 +153,7 @@ class SystemLoader(object):
         self._system_signal_cache = {}
         self._compu_method_cache = {}
         self._sw_base_type_cache = {}
+        self._arxml_reference_cache = {}
 
     def load(self):
         buses = []
@@ -548,6 +549,147 @@ class SystemLoader(object):
         ]
 
         return self.root.find(make_xpath(location), NAMESPACES)
+
+    def follow_arxml_reference(self, base_elem, arxml_path, child_tag_name):
+        """Follow a relative or absolute ARXML reference
+
+        It returns the ElementTree node which corrosponds to the given
+        path through the ARXML package structure. If no such node
+        exists, a ValueError exception is raised.
+        """
+
+        is_absolute_path = arxml_path.startswith('/')
+
+        if is_absolute_path and arxml_path in self._arxml_reference_cache:
+            return self._arxml_reference_cache[arxml_path]
+
+        base_elem = self.root if is_absolute_path else base_elem
+        if not base_elem:
+            raise ValueError(
+                'Tried to dereference a relative ARXML path without a specifying the base location.')
+
+        short_names = arxml_path.lstrip('/').split('/')
+        location = []
+
+        for short_name in short_names[:-1]:
+            location += [
+                'AR-PACKAGES',
+                "AR-PACKAGE/[ns:SHORT-NAME='{}']".format(short_name)
+            ]
+
+        location += [
+            'ELEMENTS',
+            "{}/[ns:SHORT-NAME='{}']".format(child_tag_name,
+                                             short_names[-1])
+        ]
+
+        result = base_elem.find(make_xpath(location), NAMESPACES)
+
+        if is_absolute_path:
+            self._arxml_reference_cache[arxml_path] = result
+
+        return result
+
+    def get_arxml_children(self, base_elems, children_location):
+        """Locate a set of ElementTree child nodes at a given location.
+
+        This is a method that retrieves a list of ElementTree nodes
+        that match a given ARXML location. An ARXML location is a list
+        of strings that specify the nesting order of the XML tag
+        names; potential references for entries are preceeded by an
+        '&': If a sub-element that exhibits the specified name, it is
+        used directly while if there is a sub-node called
+        '{child_tag_name}-REF' it is assumed to contain an ARXML
+        reference. This reference is then resolved and the remaining
+        location specification is relative to the result of that
+        resolution. If a location atom is preceeded by '*', then
+        multiple sub-elements are possible. The '&' and '*' qualifiers
+        may be combined.
+
+        Example:
+
+        # Return all frame triggerings in any physical channel of a
+        # CAN cluster, where each conditional, each the physical
+        # channel and its individual frame triggerings can be
+        # references
+        loader.get_arxml_children(can_cluster,
+                                   [ 'CAN-CLUSTER-VARIANTS',
+                                     '*&CAN-CLUSTER-CONDITIONAL',
+                                     'PHYSICAL-CHANNELS',
+                                     '*&CAN-PHYSICAL-CHANNEL',
+                                     'FRAME-TRIGGERINGS',
+                                     '*&CAN-FRAME-TRIGGERING'])
+        """
+
+        if base_elems is None:
+            raise ValueError('Cannot retrieve a child element of a non-existing node!')
+
+        # make sure that the children_location is a list. for convenience we
+        # also allow it to be a string. In this case we take it that a
+        # direct child node needs to be found.
+        if isinstance(children_location, str):
+            children_location = [ children_location ]
+
+        # make sure that the base elements are iterable. for
+        # convenience we also allow it to be an individiual node.
+        if type(base_elems).__name__ == 'Element':
+            base_elems = [base_elems]
+
+        for child_tag_name in children_location:
+            if len(base_elems) == 0:
+                return [] # the base elements left are the empty set...
+
+            # handle the set and reference specifiers of the current
+            # sub-location
+            allow_references = '&' in child_tag_name[:2]
+            is_nodeset = '*' in child_tag_name[:2]
+
+            if allow_references:
+                child_tag_name = child_tag_name[1:]
+            if is_nodeset:
+                child_tag_name = child_tag_name[1:]
+
+            # traverse the specified path one level deeper
+            result = []
+            for base_elem in base_elems:
+                local_result = []
+
+                for child_elem in base_elem:
+                    if child_elem.tag == f'{{{NAMESPACE}}}{child_tag_name}':
+                        local_result.append(child_elem)
+                    elif child_elem.tag == f'{{{NAMESPACE}}}{child_tag_name}-REF':
+                        tmp = self.follow_arxml_reference(base_elem, child_elem.text, child_elem.attrib.get('DEST'))
+                        if tmp is None:
+                            raise ValueError(f'Encountered dangling reference {child_tag_name}-REF: {child_elem.text}')
+
+                        local_result.append(tmp)
+
+                if not is_nodeset and len(local_result) > 1:
+                    raise ValueError(f'Encountered a a non-unique child node of type {child_tag_name} which ought to be unique')
+                    
+                result.extend(local_result)
+
+            base_elems = result
+
+        return base_elems
+
+    def get_unique_arxml_child(self, base_elem, child_location):
+        """This method does the same as get_arxml_children, but it assumes
+        that the location yields at most a single node.
+
+        It returns None if no match was found and it raises ValueError
+        if multiple nodes match the location, i.e., the returned
+        object can be used directly if the corresponding node is
+        assumed to be present.
+        """
+
+        tmp = self.get_arxml_children(base_elem, child_location)
+        if len(tmp) == 0:
+            return None
+        elif len(tmp) == 1:
+            return tmp[0]
+        else:
+            raise ValueError(f'{child_location} does not resolve into a unique node')
 
     def find_can_frame(self, xpath):
         return self.find('CAN-FRAME', xpath)

--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -229,7 +229,8 @@ class SystemLoader(object):
             self.get_unique_arxml_child(i_signal_to_i_pdu_mapping,
                                         'PACKING-BYTE-ORDER')
 
-        if packing_byte_order is not None and packing_byte_order.text == 'MOST-SIGNIFICANT-BYTE-FIRST':
+        if packing_byte_order is not None \
+           and packing_byte_order.text == 'MOST-SIGNIFICANT-BYTE-FIRST':
             return 'big_endian'
         else:
             return 'little_endian'
@@ -283,7 +284,7 @@ class SystemLoader(object):
                                                    ]):
             lower_limit = self.get_unique_arxml_child(compu_scale, 'LOWER-LIMIT')
             upper_limit = self.get_unique_arxml_child(compu_scale, 'UPPER-LIMIT')
-            vt = self.get_unique_arxml_child(compu_scale, [ '&COMPU-CONST', 'VT' ])
+            vt = self.get_unique_arxml_child(compu_scale, ['&COMPU-CONST', 'VT'])
 
             if vt is not None:
                 choices[vt.text] = int(lower_limit.text)
@@ -356,7 +357,7 @@ class SystemLoader(object):
 
             lower_limit = self.get_unique_arxml_child(compu_scale, 'LOWER-LIMIT')
             upper_limit = self.get_unique_arxml_child(compu_scale, 'UPPER-LIMIT')
-            vt = self.get_unique_arxml_child(compu_scale, [ '&COMPU-CONST', 'VT' ])
+            vt = self.get_unique_arxml_child(compu_scale, ['&COMPU-CONST', 'VT'])
 
             if vt is not None:
                 choices[vt.text] = int(lower_limit.text)
@@ -389,17 +390,21 @@ class SystemLoader(object):
             category = category.text
 
             if category == 'TEXTTABLE':
-                minimum, maximum, choices = self.load_texttable(compu_method, decimal)
+                minimum, maximum, choices = \
+                    self.load_texttable(compu_method, decimal)
             elif category == 'LINEAR':
-                minimum, maximum, factor, offset = self.load_linear(compu_method, decimal)
+                minimum, maximum, factor, offset = \
+                    self.load_linear(compu_method, decimal)
             elif category == 'SCALE_LINEAR_AND_TEXTTABLE':
                 (minimum,
                  maximum,
                  factor,
                  offset,
-                 choices) = self.load_scale_linear_and_texttable(compu_method, decimal)
+                 choices) = self.load_scale_linear_and_texttable(compu_method,
+                                                                 decimal)
             else:
-                LOGGER.debug('Compu method category %s is not yet implemented.', category)
+                LOGGER.debug('Compu method category %s is not yet implemented.',
+                             category)
 
         return minimum, maximum, factor, offset, choices
 
@@ -444,7 +449,8 @@ class SystemLoader(object):
         base_elem = self.root if is_absolute_path else base_elem
         if not base_elem:
             raise ValueError(
-                'Tried to dereference a relative ARXML path without a specifying the base location.')
+                'Tried to dereference a relative ARXML path without '
+                'specifying the base location.')
 
         short_names = arxml_path.lstrip('/').split('/')
         location = []
@@ -491,16 +497,19 @@ class SystemLoader(object):
         # channel and its individual frame triggerings can be
         # references
         loader.get_arxml_children(can_cluster,
-                                   [ 'CAN-CLUSTER-VARIANTS',
-                                     '*&CAN-CLUSTER-CONDITIONAL',
-                                     'PHYSICAL-CHANNELS',
-                                     '*&CAN-PHYSICAL-CHANNEL',
-                                     'FRAME-TRIGGERINGS',
-                                     '*&CAN-FRAME-TRIGGERING'])
+                                   [
+                                       'CAN-CLUSTER-VARIANTS',
+                                       '*&CAN-CLUSTER-CONDITIONAL',
+                                       'PHYSICAL-CHANNELS',
+                                       '*&CAN-PHYSICAL-CHANNEL',
+                                       'FRAME-TRIGGERINGS',
+                                       '*&CAN-FRAME-TRIGGERING'
+                                   ])
         """
 
         if base_elems is None:
-            raise ValueError('Cannot retrieve a child element of a non-existing node!')
+            raise ValueError(
+                'Cannot retrieve a child element of a non-existing node!')
 
         # make sure that the children_location is a list. for convenience we
         # also allow it to be a string. In this case we take it that a
@@ -536,14 +545,21 @@ class SystemLoader(object):
                     if child_elem.tag == f'{{{NAMESPACE}}}{child_tag_name}':
                         local_result.append(child_elem)
                     elif child_elem.tag == f'{{{NAMESPACE}}}{child_tag_name}-REF':
-                        tmp = self.follow_arxml_reference(base_elem, child_elem.text, child_elem.attrib.get('DEST'))
+                        tmp = self.follow_arxml_reference(base_elem,
+                                                          child_elem.text,
+                                                          child_elem.attrib.get('DEST'))
+
                         if tmp is None:
-                            raise ValueError(f'Encountered dangling reference {child_tag_name}-REF: {child_elem.text}')
+                            raise ValueError(f'Encountered dangling reference '
+                                             f'{child_tag_name}-REF: '
+                                             f'{child_elem.text}')
 
                         local_result.append(tmp)
 
                 if not is_nodeset and len(local_result) > 1:
-                    raise ValueError(f'Encountered a a non-unique child node of type {child_tag_name} which ought to be unique')
+                    raise ValueError(f'Encountered a a non-unique child node '
+                                     f'of type {child_tag_name} which ought to '
+                                     f'be unique')
 
                 result.extend(local_result)
 

--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -183,6 +183,10 @@ class SystemLoader(object):
                                                     NAMESPACES).text
         can_frame = self.find_can_frame(frame_ref_xpath)
 
+        if can_frame is None:
+            # dangling reference to the can frame object.
+            raise ValueError(f"Encountered dangling reference FRAME-REF: {frame_ref_xpath}")
+
         # Name, frame id, length, is_extended_frame and comment.
         name = self.load_message_name(can_frame)
         frame_id = self.load_message_frame_id(can_frame_triggering)

--- a/tests/files/arxml/system-dangling-reference-4.2.arxml
+++ b/tests/files/arxml/system-dangling-reference-4.2.arxml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AUTOSAR xsi:schemaLocation="http://autosar.org/schema/r4.0 AUTOSAR_00046.xsd" xmlns="http://autosar.org/schema/r4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <AR-PACKAGES>
+    <AR-PACKAGE>
+      <SHORT-NAME>Cluster</SHORT-NAME>
+      <ELEMENTS>
+        <CAN-CLUSTER>
+          <SHORT-NAME>Cluster0</SHORT-NAME>
+          <CAN-CLUSTER-VARIANTS>
+            <CAN-CLUSTER-CONDITIONAL>
+              <BAUDRATE>500000</BAUDRATE>
+              <PHYSICAL-CHANNELS>
+                <CAN-PHYSICAL-CHANNEL>
+                  <SHORT-NAME>Pch0</SHORT-NAME>
+                  <FRAME-TRIGGERINGS>
+                    <CAN-FRAME-TRIGGERING>
+                      <SHORT-NAME>message1</SHORT-NAME>
+                      <FRAME-REF DEST="CAN-FRAME">/PackageDoesNotExist/Message1</FRAME-REF>
+                      <CAN-ADDRESSING-MODE>STANDARD</CAN-ADDRESSING-MODE>
+                      <IDENTIFIER>5</IDENTIFIER>
+                    </CAN-FRAME-TRIGGERING>
+                  </FRAME-TRIGGERINGS>
+                </CAN-PHYSICAL-CHANNEL>
+              </PHYSICAL-CHANNELS>
+            </CAN-CLUSTER-CONDITIONAL>
+          </CAN-CLUSTER-VARIANTS>
+        </CAN-CLUSTER>
+      </ELEMENTS>
+    </AR-PACKAGE>
+  </AR-PACKAGES>
+</AUTOSAR>


### PR DESCRIPTION
This PR continues the quest for ARXML-3 support, cf https://github.com/Daimler/cantools/tree/arxml_refactor

In this PR a set improved of traversal functions for ARXML documents is introduced and the existing code is changed to use them. The main advantage of them is that they make it very easy to follow ARXML references and to specifies colletions of XML nodes which might have ARXML references in their location.

Be aware that I'm not sure where exactly references are allowed by the AUTOSAR standard or how to obtain that information, so I've enabled them quite liberally. The rationale is that if AUTOSAR does not allow references in a given context but we support them anyway, well-formed files will still load fine.

Andreas Lauser <andreas.lauser@mbition.io>, Mercedes-Benz AG on behalf of [MBition GmbH](https://mbition.io/).

[Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md#mbition-gmbh)