### PR TITLE
implement multi-lingual message and signal descriptions

### DIFF
--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -43,8 +43,8 @@ class SystemLoader(object):
         self.autosar_version_minor = 0 if m.group(2) is None else int(m.group(2)[1:])
         self.autosar_version_patch = 0 if m.group(3) is None else int(m.group(3)[1:])
 
-        if self.autosar_version_major != 4 and self.autosar_version_major != 3:
-            raise ValueError('This class only supports AUTOSAR versions 3 and 4')
+        if self.autosar_version_major != 4:
+            raise ValueError('This class only supports AUTOSAR version 4')
 
         self._arxml_reference_cache = {}
 
@@ -562,7 +562,7 @@ class SystemLoader(object):
         # CAN cluster, where each conditional, each the physical
         # channel and its individual frame triggerings can be
         # references
-        loader.get_arxml_children(can_cluster,
+        loader._get_arxml_children(can_cluster,
                                    [
                                        'CAN-CLUSTER-VARIANTS',
                                        '*&CAN-CLUSTER-CONDITIONAL',

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -55,7 +55,19 @@ class Message(object):
         self._length = length
         self._signals = signals
         self._signals.sort(key=start_bit)
-        self._comment = comment
+
+        # if the 'comment' argument is a string, we assume that is an
+        # english comment. this is slightly hacky because the
+        # function's behavior depends on the type of the passed
+        # argument, but it is quite convenient...
+        if isinstance(comment, str):
+            # use the first comment in the dictionary as "The" comment
+            self._comments = { None: comment }
+        else:
+            # assume that we have either no comment at all or a
+            # multi-lingual dictionary
+            self._comments = comment
+
         self._senders = senders if senders else []
         self._send_type = send_type
         self._cycle_time = cycle_time
@@ -220,13 +232,31 @@ class Message(object):
     def comment(self):
         """The message comment, or ``None`` if unavailable.
 
-        """
+        Note that we implicitly try to return the comment's language
+        to be English comment if multiple languages were specified.
 
-        return self._comment
+        """
+        if self._comments is None:
+            return None
+        elif self._comments.get(None) is not None:
+            return self._comments.get(None)
+
+        return self._comments.get('EN', None)
+
+    @property
+    def comments(self):
+        """The dictionary with the descriptions of the message in multiple languages. ``None`` if unavailable.
+
+        """
+        return self._comments
 
     @comment.setter
     def comment(self, value):
-        self._comment = value
+        self._comments = { None: value }
+
+    @comments.setter
+    def comments(self, value):
+        self._comments = value
 
     @property
     def senders(self):
@@ -910,4 +940,4 @@ class Message(object):
             self._frame_id,
             self._is_extended_frame,
             self._length,
-            "'" + self._comment + "'" if self._comment is not None else None)
+            self._comments)

--- a/cantools/database/can/signal.py
+++ b/cantools/database/can/signal.py
@@ -140,7 +140,19 @@ class Signal(object):
         self._unit = unit
         self._choices = choices
         self._dbc = dbc_specifics
-        self._comment = comment
+
+        # if the 'comment' argument is a string, we assume that is an
+        # english comment. this is slightly hacky because the
+        # function's behavior depends on the type of the passed
+        # argument, but it is quite convenient...
+        if isinstance(comment, str):
+            # use the first comment in the dictionary as "The" comment
+            self._comments = { None: comment }
+        else:
+            # assume that we have either no comment at all or a
+            # multi-lingual dictionary
+            self._comments = comment
+
         self._receivers = [] if receivers is None else receivers
         self._is_multiplexer = is_multiplexer
         self._multiplexer_ids = multiplexer_ids
@@ -334,13 +346,32 @@ class Signal(object):
     def comment(self):
         """The signal comment, or ``None`` if unavailable.
 
+        Note that we implicitly try to return the comment's language
+        to be English comment if multiple languages were specified.
+    
         """
+        if self._comments is None:
+            return None
+        elif self._comments.get(None) is not None:
+            return self._comments.get(None)
 
-        return self._comment
+        return self._comments.get('EN', None)
+
+    @property
+    def comments(self):
+        """The dictionary with the descriptions of the signal in multiple
+        languages. ``None`` if unavailable.
+
+        """
+        return self._comments
 
     @comment.setter
     def comment(self, value):
-        self._comment = value
+        self._comments = { None: value }
+
+    @comments.setter
+    def comments(self, value):
+        self._comments = value
 
     @property
     def receivers(self):
@@ -431,4 +462,4 @@ class Signal(object):
             self._multiplexer_ids,
             choices,
             self._spn,
-            "'" + self._comment + "'" if self._comment is not None else None)
+            self._comments)

--- a/tests/files/arxml/system-4.2.arxml
+++ b/tests/files/arxml/system-4.2.arxml
@@ -44,7 +44,10 @@
       <ELEMENTS>
         <CAN-FRAME>
           <SHORT-NAME>Message1</SHORT-NAME>
-          <DESC><L-2 L="FOR-ALL">Comment1</L-2></DESC>
+          <DESC>
+            <L-2 L="EN">Comment1</L-2>
+            <L-2 L="DE">Kommentar1</L-2>
+          </DESC>
           <FRAME-LENGTH>6</FRAME-LENGTH>
           <PDU-TO-FRAME-MAPPINGS>
             <PDU-TO-FRAME-MAPPING>
@@ -289,6 +292,10 @@
       <ELEMENTS>
         <SYSTEM-SIGNAL>
           <SHORT-NAME>Signal1</SHORT-NAME>
+          <DESC>
+            <L-2 L="EN">Signal comment!</L-2>
+            <L-2 L="DE">Signalkommentar!</L-2>
+          </DESC>
           <PHYSICAL-PROPS>
             <SW-DATA-DEF-PROPS-VARIANTS>
               <SW-DATA-DEF-PROPS-CONDITIONAL>

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -55,8 +55,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
                          "message('RT_SB_INS_Vel_Body_Axes', 0x9588322, True, 8, None)")
         self.assertEqual(repr(db.messages[0].signals[0]),
                          "signal('Validity_INS_Vel_Forwards', 0, 1, 'little_endian', "
-                         "False, 0, 1, 0, 0, 1, 'None', False, None, None, None, 'Valid when "
-                         "bit is set, invalid when bit is clear.')")
+                         "False, 0, 1, 0, 0, 1, 'None', False, None, None, None, {None: 'Valid when "
+                         "bit is set, invalid when bit is clear.'})")
         self.assertEqual(db.messages[0].signals[0].initial, 0)
         self.assertEqual(db.messages[0].signals[0].receivers, [])
         self.assertEqual(db.messages[0].cycle_time, None)
@@ -83,8 +83,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(
             repr(signal),
             "signal('Validity_Accel_Longitudinal', 0, 1, 'little_endian', False, "
-            "None, 1, 0, None, None, 'None', False, None, None, None, 'Valid when bit is "
-            "set, invalid when bit is clear.')")
+            "None, 1, 0, None, None, 'None', False, None, None, None, {None: 'Valid when bit is "
+            "set, invalid when bit is clear.'})")
 
         signal = message.get_signal_by_name('Validity_Accel_Lateral')
         self.assertEqual(signal.initial , 1)
@@ -100,9 +100,9 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(
             repr(signal),
             "signal('Accel_Longitudinal', 16, 16, 'little_endian', True, 32767, "
-            "0.001, 0, -65, 65, 'g', False, None, None, None, 'Longitudinal "
+            "0.001, 0, -65, 65, 'g', False, None, None, None, {None: 'Longitudinal "
             "acceleration.  This is positive when the vehicle accelerates in a "
-            "forwards direction.')")
+            "forwards direction.'})")
 
         signal = message.get_signal_by_name('Accel_Lateral')
         self.assertEqual(signal.initial , -30000)
@@ -204,11 +204,11 @@ class CanToolsDatabaseTest(unittest.TestCase):
             "node('FIE', None)\n"
             "node('FUM', None)\n"
             "\n"
-            "message('Foo', 0x12330, True, 8, 'Foo.')\n"
+            "message('Foo', 0x12330, True, 8, {None: 'Foo.'})\n"
             "  signal('Foo', 0, 12, 'big_endian', True, None, 0.01, "
             "250, 229.53, 270.47, 'degK', False, None, None, None, None)\n"
             "  signal('Bar', 24, 32, 'big_endian', True, None, 0.1, "
-            "0, 0, 5, 'm', False, None, None, None, 'Bar.')\n"
+            "0, 0, 5, 'm', False, None, None, None, {None: 'Bar.'})\n"
             "\n"
             "message('Fum', 0x12331, True, 5, None)\n"
             "  signal('Fum', 0, 12, 'little_endian', True, None, 1, 0, 0, 10, "
@@ -4320,9 +4320,18 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(message_1.send_type, None)
         self.assertEqual(message_1.cycle_time, None)
         self.assertEqual(len(message_1.signals), 3)
-        self.assertEqual(message_1.comment, 'Comment1')
+        self.assertEqual(message_1.comments["DE"], 'Kommentar1')
+        self.assertEqual(message_1.comments["EN"], 'Comment1')
         self.assertEqual(message_1.bus_name, None)
+        self.assertEqual(message_1.comment, 'Comment1')
+        message_1.comments = {'DE': 'Kommentar eins', 'EN': 'Comment one'}
+        self.assertEqual(message_1.comments,
+                         {
+                             'DE': 'Kommentar eins',
+                             'EN' : 'Comment one'
+                         })
 
+        
         signal_1 = message_1.signals[0]
         self.assertEqual(signal_1.name, 'signal6')
         self.assertEqual(signal_1.start, 0)
@@ -4363,7 +4372,16 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_2.decimal.maximum, 4.0)
         self.assertEqual(signal_2.unit, 'm')
         self.assertEqual(signal_2.choices, None)
-        self.assertEqual(signal_2.comment, None)
+        self.assertEqual(signal_2.comments["EN"],'Signal comment!' )
+        self.assertEqual(signal_2.comments["DE"],'Signalkommentar!' )
+        self.assertEqual(signal_2.comment, 'Signal comment!')
+        signal_2.comments = {'DE': 'Kein Kommentar!', 'EN': 'No comment!'}
+        self.assertEqual(signal_2.comments,
+                         {
+                             'DE': 'Kein Kommentar!',
+                             'EN': 'No comment!'
+                         })
+
         self.assertEqual(signal_2.is_multiplexer, False)
         self.assertEqual(signal_2.multiplexer_ids, None)
 
@@ -4441,7 +4459,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_2.decimal.maximum, None)
         self.assertEqual(signal_2.unit, None)
         self.assertEqual(signal_2.choices, None)
-        self.assertEqual(signal_2.comment, 'Signal comment!')
+        self.assertEqual(signal_2.comments["FOR-ALL"], 'Signal comment!')
         self.assertEqual(signal_2.is_multiplexer, False)
         self.assertEqual(signal_2.multiplexer_ids, None)
 


### PR DESCRIPTION
This PR continues the quest for ARXML-3 support, cf https://github.com/andlaus/cantools/tree/arxml_refactor

ATTENTION: This patch includes some changes outside of the ARXML loader.

For now, the default is to assume that comments which don't explicitly specify a language are in English. An alternative would be to check if the dictionary containing the comments contains exactly a single element and use that instead. The problem with this approach is that comments for different languages might get mixed up more easily: Assume a supplier based in China who documents its signals only in Chinese and a OEM based in Brazil who likes to document its stuff using Portuguese...

Andreas Lauser <andreas.lauser@mbition.io>, Mercedes-Benz AG on behalf of [MBition GmbH](https://mbition.io/).

[Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md#mbition-gmbh)
