### PR TITLE
ARXML: fix determining signal lengths their initial value and its range

### DIFF
--- a/tests/files/arxml/system-4.2.arxml
+++ b/tests/files/arxml/system-4.2.arxml
@@ -99,6 +99,11 @@
       <ELEMENTS>
         <I-SIGNAL UUID="52b93c1cec70bd40a590ece0b3893c0d">
           <SHORT-NAME>signal1</SHORT-NAME>
+          <INIT-VALUE>
+            <NUMERICAL-VALUE-SPECIFICATION>
+              <VALUE>5</VALUE>
+            </NUMERICAL-VALUE-SPECIFICATION>
+          </INIT-VALUE>
           <LENGTH>3</LENGTH>
           <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignal/Signal1</SYSTEM-SIGNAL-REF>
         </I-SIGNAL>
@@ -167,9 +172,28 @@
         </I-SIGNAL>
         <I-SIGNAL UUID="7ac5ce20002a1a4a3c4beb72b17bc1b5">
           <SHORT-NAME>signal6</SHORT-NAME>
+          <INIT-VALUE>
+            <CONSTANT-REFERENCE>
+              <CONSTANT-REF DEST="CONSTANT-SPECIFICATION">/Constants/BooleanFalse</CONSTANT-REF>
+            </CONSTANT-REFERENCE>
+          </INIT-VALUE>
           <LENGTH>1</LENGTH>
           <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignal/Signal6</SYSTEM-SIGNAL-REF>
         </I-SIGNAL>
+      </ELEMENTS>
+    </AR-PACKAGE>
+    <AR-PACKAGE UUID="89cb5634c5ae4850b6dd0ba310fbc247">
+      <SHORT-NAME>Constants</SHORT-NAME>
+      <ELEMENTS>
+        <CONSTANT-SPECIFICATION UUID="0778143a6fc7ae0b1bcc9670853fe048">
+          <SHORT-NAME>BooleanFalse</SHORT-NAME>
+          <VALUE-SPEC>
+            <NUMERICAL-VALUE-SPECIFICATION>
+              <SHORT-LABEL>literal</SHORT-LABEL>
+              <VALUE>false</VALUE>
+            </NUMERICAL-VALUE-SPECIFICATION>
+          </VALUE-SPEC>
+        </CONSTANT-SPECIFICATION>
       </ELEMENTS>
     </AR-PACKAGE>
     <AR-PACKAGE UUID="bf5ded8d0c2d7bd37cfb17f2525d7208">

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -4336,6 +4336,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_1.name, 'signal6')
         self.assertEqual(signal_1.start, 0)
         self.assertEqual(signal_1.length, 1)
+        self.assertEqual(signal_1.initial, False)
         self.assertEqual(signal_1.receivers, [])
         self.assertEqual(signal_1.byte_order, 'little_endian')
         self.assertEqual(signal_1.is_signed, False)
@@ -4358,6 +4359,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_2.name, 'signal1')
         self.assertEqual(signal_2.start, 4)
         self.assertEqual(signal_2.length, 3)
+        self.assertEqual(signal_2.initial, 5)
         self.assertEqual(signal_2.receivers, [])
         self.assertEqual(signal_2.byte_order, 'big_endian')
         self.assertEqual(signal_2.is_signed, False)
@@ -4388,6 +4390,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         signal_3 = message_1.signals[2]
         self.assertEqual(signal_3.name, 'signal5')
         self.assertEqual(signal_3.start, 16)
+        self.assertEqual(signal_3.initial, None)
         self.assertEqual(signal_3.length, 32)
         self.assertEqual(signal_3.receivers, [])
         self.assertEqual(signal_3.byte_order, 'little_endian')
@@ -4549,6 +4552,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
                              'Cluster',
                              'CanFrame',
                              'ISignal',
+                             'Constants',
                              'ISignalIPdu',
                              'Unit',
                              'CompuMethod',


### PR DESCRIPTION
This PR continues the quest for ARXML-3 support, cf https://github.com/andlaus/cantools/tree/arxml_refactor

This PR adds support for determining the length of a given signal via the system signal if the length is not specified by the i-signal itself (first patch),  it corrects determining the possible range of signals (second patch; the possible value range of the signal is the range over all COMPU-SCALEs, not just the first one)  and it implements loading the initial value of signals (third patch).

The next PR will contain the changes for the differences between ARXML-3 and ARXML-4.

Andreas Lauser <andreas.lauser@mbition.io>, Mercedes-Benz AG on behalf of [MBition GmbH](https://mbition.io/).

[Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md#mbition-gmbh)