### PR TITLE
sets initial signal value when none supplied during encoding

### DIFF
--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -707,10 +707,13 @@ class Message(object):
     def _check_signals(self, signals, data, scaling):
         for signal in signals:
             if signal.name not in data:
-                raise EncodeError(
-                    "Expected signal value for '{}' in data, but got {}.".format(
-                        signal.name,
-                        data))
+                if signal.initial is not None:
+                    data[signal.name] = signal.initial
+                else:
+                    raise EncodeError(
+                        "Expected signal value for '{}' in data, but got {}.".format(
+                            signal.name,
+                            data))
 
         if scaling:
             self._check_signals_ranges_scaling(signals, data)

--- a/cantools/database/can/signal.py
+++ b/cantools/database/can/signal.py
@@ -1,4 +1,6 @@
 # A CAN signal.
+from ..errors import EncodeError
+
 
 class Decimal(object):
     """Holds the same values as
@@ -437,6 +439,33 @@ class Signal(object):
         for choice_number, choice_string in self.choices.items():
             if choice_string == string:
                 return choice_number
+
+    def encode(self, message, data=None, scaling=True, padding=False, strict=True):
+        """
+        Encode a signal directly
+
+        This will encode a message where all other signals in the message have initial
+        values set and you want to ue those initial values. If there is a multiplexer_signal
+        for this signal then that will also get set to this signal name
+
+        :param message: The message this signal is apart of
+        :param data: the data to set or None if there has been an initial value set and that is what is to be used
+        :type data: optional, any
+        """
+        if data is None:
+            if self.initial is not None:
+                data = {self.name: self.initial}
+            else:
+                raise EncodeError(
+                    "You must supply a signal value for signal {0}".format(self.name)
+                )
+        else:
+            data = {self.name: data}
+
+        if self.multiplexer_signal is not None:
+            data[self.multiplexer_signal] = self.name
+
+        return message.encode(data, scaling=scaling, padding=padding, strict=strict)
 
     def __repr__(self):
         if self._choices is None:


### PR DESCRIPTION
This is a 2 fold PR because one change is dependent on the other. When encoding a message if a signal was not supplied in the data to be encoded but the signal has an initial value an EncodeError would be raised. This PR changes that behavior to check for an initial value and if one is available it will use that to encode the message with

The second part is to allow encoding a message from the signal directly. The use case for this is if all other signals that are apart of the message have a default value the signal can directly be used to encode a message with the supplied value. It also takes into account if the signal has a multiplexer signal and if it does it sets the value of the multiplexer signal to the name of the signal where encode() was called.

I am sure that there might be a better way to go about handling this and I do not have an in depth knowledge of can databases. 
In my specific use case I have updated the OBD2.dbc file that is available from

https://www.csselectronics.com/screen/product/obd2-dbc-file/language/en

which in it's downloaded form only decodes messages and does not have the ability to encode messages. I have updated it so it now does have the ability to decode messages and this is done by using initial values and multiplexers. So no actual data needs to be supplied in order to encode an OBD2 message.

If a copy of the updated version of the OBD database file is wanted let me know and I will upload it.

use code example
```python
import cantools

db = cantools.db.load_file(r'OBD2.dbc')
message = db.get_message_by_name('OBD2_TX')

signal = message.get_signal_by_name('Odometer')
print(signal.encode(message))

data = {
    'ParameterID_Service01': 'Odometer',
    'Odometer': 0,
    'service': 1,
    'length': 2
}

print(message.encode(data))
```

and the output is exactly the same
```
b'\x02\x01\xa6\x00\x00\x00\x00\x00'
b'\x02\x01\xa6\x00\x00\x00\x00\x00'
```
so in order to transmit the obd2 request the only information that is needed is the name of the message and the name of the signal. Where as the current code makes it so that quite a bit of information needs to be known in order to encode the exact same message.

This is more of a proof of concept then anything else and I am sure that it can be improved upon. My database alterations are within the specification and I am using Vector CANdb++ to make the changes so it is within the ability of the current specification to function in this manner.