### PR TITLE
Add a CLI flag to disable the snake_case conversion of message and signal names

### DIFF
--- a/cantools/subparsers/generate_c_source.py
+++ b/cantools/subparsers/generate_c_source.py
@@ -29,7 +29,8 @@ def _do_generate_c_source(args):
         filename_c,
         fuzzer_filename_c,
         not args.no_floating_point_numbers,
-        args.bit_fields)
+        args.bit_fields,
+        args.disable_snake_case_conversion)
 
     with open(filename_h, 'w') as fout:
         fout.write(header)
@@ -81,6 +82,10 @@ def add_subparser(subparsers):
         '-f', '--generate-fuzzer',
         action='store_true',
         help='Also generate fuzzer source code.')
+    generate_c_source_parser.add_argument(
+        '--disable-snake-case-conversion',
+        action='store_true',
+        help='Disables the default behaviour of converting message and signal names to snake_case.')
     generate_c_source_parser.add_argument(
         'infile',
         help='Input database file.')


### PR DESCRIPTION
We have a use case in which we wish to preserve message and signal names in the original form in the generated C source code. This PR adds a CLI flag that disables the default behaviour of converting all message and signal names to snake_case.

It ads a guard around each use of `camel_to_snake_case()`. If `disable_snake_case_conversion` is true then we only perform the `_canonical()` sanitation. It also changes `self.snake_name` to `self.exported_name` for messages and signals.

A cleaner solution would be to create a `generator` class which stores the settings for the generation, and make all generator functions methods of the new class, rather than passing the new argument into every function in the call tree that includes `camel_to_snake_case`, but that would be a bigger architectural change.

If this is a change that other people are likely to find useful, let me know and I'll finish off this PR. As it stands we'll probably continue to use my fork internally.

- [ ] WIP
- [ ] Add tests
- [ ] Update readme