### PR TITLE
Make matplotlib optional

### DIFF
--- a/cantools/subparsers/plot.py
+++ b/cantools/subparsers/plot.py
@@ -48,7 +48,10 @@ import struct
 import datetime
 import argparse
 from argparse_addons import Integer
-from matplotlib import pyplot as plt
+try:
+    from matplotlib import pyplot as plt
+except ImportError:
+    print("matplotlib package not installed. Required for producing plots.")
 
 from .. import database
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(name='cantools',
           'textparser>=0.21.1',
           'diskcache',
           'argparse_addons',
-          'matplotlib'
       ],
       test_suite="tests",
       entry_points = {


### PR DESCRIPTION
Regarding issue #259.

This patch makes matplotlib optional and prints a helpful message if it fails to import at runtime.