### PR TITLE
Handle missing matplotlib more nicely.

### DIFF
--- a/cantools/__init__.py
+++ b/cantools/__init__.py
@@ -35,14 +35,18 @@ def _main():
     from .subparsers import dump
     from .subparsers import convert
     from .subparsers import generate_c_source
-    from .subparsers import plot
+
+    try:
+        from .subparsers import plot
+        plot.add_subparser(subparsers)
+    except ImportError as e:
+        print("plot subparser unavailable: {}".format(e))
 
     decode.add_subparser(subparsers)
     monitor.add_subparser(subparsers)
     dump.add_subparser(subparsers)
     convert.add_subparser(subparsers)
     generate_c_source.add_subparser(subparsers)
-    plot.add_subparser(subparsers)
 
     args = parser.parse_args()
 

--- a/cantools/subparsers/plot.py
+++ b/cantools/subparsers/plot.py
@@ -52,6 +52,7 @@ try:
     from matplotlib import pyplot as plt
 except ImportError:
     print("matplotlib package not installed. Required for producing plots.")
+    raise ImportError("matplotlib not installed")
 
 from .. import database
 


### PR DESCRIPTION
This should've been a part of #260 

My main unknown is if we want to print to console on the `plot` subparser being unavailable, or just silently leave it out?