### PR TITLE
Add --output-directory option to generage_c_source command

### DIFF
--- a/cantools/subparsers/generate_c_source.py
+++ b/cantools/subparsers/generate_c_source.py
@@ -31,23 +31,31 @@ def _do_generate_c_source(args):
         not args.no_floating_point_numbers,
         args.bit_fields)
 
-    with open(filename_h, 'w') as fout:
+    path_h = os.path.join(args.output_directory, filename_h)
+    
+    with open(path_h, 'w') as fout:
         fout.write(header)
 
-    with open(filename_c, 'w') as fout:
+    path_c = os.path.join(args.output_directory, filename_c)
+
+    with open(path_c, 'w') as fout:
         fout.write(source)
 
-    print('Successfully generated {} and {}.'.format(filename_h, filename_c))
+    print('Successfully generated {} and {}.'.format(path_h, path_c))
 
     if args.generate_fuzzer:
-        with open(fuzzer_filename_c, 'w') as fout:
+        fuzzer_path_c = os.path.join(args.output_directory, fuzzer_filename_c)
+
+        with open(fuzzer_path_c, 'w') as fout:
             fout.write(fuzzer_source)
+
+        fuzzer_path_mk = os.path.join(args.output_directory, fuzzer_filename_mk)
 
         with open(fuzzer_filename_mk, 'w') as fout:
             fout.write(fuzzer_makefile)
 
-        print('Successfully generated {} and {}.'.format(fuzzer_filename_c,
-                                                         fuzzer_filename_mk))
+        print('Successfully generated {} and {}.'.format(fuzzer_path_c,
+                                                         fuzzer_path_mk))
         print()
         print(
             'Run "make -f {}" to build and run the fuzzer. Requires a'.format(
@@ -81,6 +89,10 @@ def add_subparser(subparsers):
         '-f', '--generate-fuzzer',
         action='store_true',
         help='Also generate fuzzer source code.')
+    generate_c_source_parser.add_argument(
+        '-o', '--output-directory',
+        default='.',
+        help='Directory in which to write output files.')
     generate_c_source_parser.add_argument(
         'infile',
         help='Input database file.')

--- a/cantools/subparsers/generate_c_source.py
+++ b/cantools/subparsers/generate_c_source.py
@@ -1,4 +1,5 @@
 import os
+import os.path
 
 from .. import database
 from ..database.can.c_source import generate
@@ -31,6 +32,8 @@ def _do_generate_c_source(args):
         not args.no_floating_point_numbers,
         args.bit_fields)
 
+    os.makedirs(args.output_directory, exist_ok=True)
+    
     path_h = os.path.join(args.output_directory, filename_h)
     
     with open(path_h, 'w') as fout:

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1180,8 +1180,8 @@ BATTERY_VT(
             if os.path.exists(database_c):
                 os.remove(database_c)
             
-            if os.path.exists(some_dir):
-                os.rmdir(some_dir)
+            if os.path.exists(output_directory):
+                os.rmdir(output_directory)
 
             with patch('sys.argv', argv):
                 cantools._main()

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1171,8 +1171,8 @@ BATTERY_VT(
                 'tests/files/dbc/{}.dbc'.format(database)
             ]
 
-            database_h = os.path.join(output_directory, 'my_database_name.h')
-            database_c = os.path.join(output_directory, 'my_database_name.c')
+            database_h = os.path.join(output_directory, f'{database}.h')
+            database_c = os.path.join(output_directory, f'{database}.c')
 
             if os.path.exists(database_h):
                 os.remove(database_h)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1156,6 +1156,41 @@ BATTERY_VT(
                 self.assert_files_equal(database_c,
                                         'tests/files/c_source/' + database_c)
 
+    def test_generate_c_source_output_directory(self):
+        databases = [
+            'motohawk',
+        ]
+        
+        output_directory = 'some_dir'
+
+        for database in databases:
+            argv = [
+                'cantools',
+                'generate_c_source',
+                '--output-directory', output_directory,
+                'tests/files/dbc/{}.dbc'.format(database)
+            ]
+
+            database_h = os.path.join(output_directory, 'my_database_name.h')
+            database_c = os.path.join(output_directory, 'my_database_name.c')
+
+            if os.path.exists(database_h):
+                os.remove(database_h)
+
+            if os.path.exists(database_c):
+                os.remove(database_c)
+            
+            if os.path.exists(some_dir):
+                os.rmdir(some_dir)
+
+            with patch('sys.argv', argv):
+                cantools._main()
+
+            self.assert_files_equal(database_h,
+                                    'tests/files/c_source/' + os.path.basename(database_h))
+            self.assert_files_equal(database_c,
+                                    'tests/files/c_source/' + os.path.basename(database_c))
+
     def test_generate_c_source_bit_fields(self):
         databases = [
             'motohawk',

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1172,7 +1172,7 @@ BATTERY_VT(
         database_h = os.path.join(output_directory, f'{database}.h')
         database_c = os.path.join(output_directory, f'{database}.c')
 
-        shutil.rmtree(output_directory)
+        shutil.rmtree(output_directory, ignore_errors=True)
 
         with patch('sys.argv', argv):
             cantools._main()

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1157,39 +1157,36 @@ BATTERY_VT(
                                         'tests/files/c_source/' + database_c)
 
     def test_generate_c_source_output_directory(self):
-        databases = [
-            'motohawk',
-        ]
+        database = 'motohawk'
         
         output_directory = 'some_dir'
 
-        for database in databases:
-            argv = [
-                'cantools',
-                'generate_c_source',
-                '--output-directory', output_directory,
-                'tests/files/dbc/{}.dbc'.format(database)
-            ]
+        argv = [
+            'cantools',
+            'generate_c_source',
+            '--output-directory', output_directory,
+            'tests/files/dbc/{}.dbc'.format(database)
+        ]
 
-            database_h = os.path.join(output_directory, f'{database}.h')
-            database_c = os.path.join(output_directory, f'{database}.c')
+        database_h = os.path.join(output_directory, f'{database}.h')
+        database_c = os.path.join(output_directory, f'{database}.c')
 
-            if os.path.exists(database_h):
-                os.remove(database_h)
+        if os.path.exists(database_h):
+            os.remove(database_h)
 
-            if os.path.exists(database_c):
-                os.remove(database_c)
-            
-            if os.path.exists(output_directory):
-                os.rmdir(output_directory)
+        if os.path.exists(database_c):
+            os.remove(database_c)
 
-            with patch('sys.argv', argv):
-                cantools._main()
+        if os.path.exists(output_directory):
+            os.rmdir(output_directory)
 
-            self.assert_files_equal(database_h,
-                                    'tests/files/c_source/' + os.path.basename(database_h))
-            self.assert_files_equal(database_c,
-                                    'tests/files/c_source/' + os.path.basename(database_c))
+        with patch('sys.argv', argv):
+            cantools._main()
+
+        self.assert_files_equal(database_h,
+                                'tests/files/c_source/' + os.path.basename(database_h))
+        self.assert_files_equal(database_c,
+                                'tests/files/c_source/' + os.path.basename(database_c))
 
     def test_generate_c_source_bit_fields(self):
         databases = [

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import re
+import shutil
 import unittest
 
 try:
@@ -1171,14 +1172,7 @@ BATTERY_VT(
         database_h = os.path.join(output_directory, f'{database}.h')
         database_c = os.path.join(output_directory, f'{database}.c')
 
-        if os.path.exists(database_h):
-            os.remove(database_h)
-
-        if os.path.exists(database_c):
-            os.remove(database_c)
-
-        if os.path.exists(output_directory):
-            os.rmdir(output_directory)
+        shutil.rmtree(output_directory)
 
         with patch('sys.argv', argv):
             cantools._main()


### PR DESCRIPTION
Draft for:
- [x] Actually trying it out (a friend would like this addition)
- [x] A test
- [x] Handle output directory that doesn't exist
- [x] Make it actually work again
- [x] Checking on unwanted effects on the file contents