### PR TITLE
Adds "plot" extra in setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,6 +161,13 @@ For more information see
 
     $ python3 -m cantools plot --help
 
+Note that by default matplotlib is not installed with cantools. But it can be by specifying an extra
+at installation:
+
+.. code-block:: python
+
+    python3 -m pip install cantools[plot]
+
 The dump subcommand
 ^^^^^^^^^^^^^^^^^^^
 

--- a/README.rst
+++ b/README.rst
@@ -166,7 +166,7 @@ at installation:
 
 .. code-block:: python
 
-    python3 -m pip install cantools[plot]
+    $ python3 -m pip install cantools[plot]
 
 The dump subcommand
 ^^^^^^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ setup(name='cantools',
           'diskcache',
           'argparse_addons',
       ],
+      extras_require=dict(
+          plot=['matplotlib'],
+      ),
       test_suite="tests",
       entry_points = {
           'console_scripts': ['cantools=cantools.__init__:_main']


### PR DESCRIPTION
This declares the optional dependency to matplotlib.

In relation with #259, #260 and #265.

@eerimoq, I don't know what process you would like the contributors to follow when they author commit themselves. So for now I just make PR for review by other maintainers.