### PR TITLE
ARXML: allow to specify non-base 10 integer numbers

### DIFF
--- a/tests/files/arxml/system-4.2.arxml
+++ b/tests/files/arxml/system-4.2.arxml
@@ -101,15 +101,15 @@
           <SHORT-NAME>signal1</SHORT-NAME>
           <INIT-VALUE>
             <NUMERICAL-VALUE-SPECIFICATION>
-              <VALUE>5</VALUE>
+              <VALUE>0b101</VALUE>
             </NUMERICAL-VALUE-SPECIFICATION>
           </INIT-VALUE>
-          <LENGTH>3</LENGTH>
+          <LENGTH>0b11</LENGTH>
           <SYSTEM-SIGNAL-REF DEST="SYSTEM-SIGNAL">/SystemSignal/Signal1</SYSTEM-SIGNAL-REF>
         </I-SIGNAL>
         <I-SIGNAL UUID="b077fb759e9e255d0ddb6e6ab49b8d7c">
           <SHORT-NAME>signal2</SHORT-NAME>
-          <LENGTH>11</LENGTH>
+          <LENGTH>0xb</LENGTH>
           <NETWORK-REPRESENTATION-PROPS>
             <SW-DATA-DEF-PROPS-VARIANTS>
               <SW-DATA-DEF-PROPS-CONDITIONAL>
@@ -121,7 +121,7 @@
         </I-SIGNAL>
         <I-SIGNAL UUID="1b81d9d6c79916117b4848178814a31a">
           <SHORT-NAME>signal2_1c</SHORT-NAME>
-          <LENGTH>11</LENGTH>
+          <LENGTH>013</LENGTH>
           <NETWORK-REPRESENTATION-PROPS>
             <SW-DATA-DEF-PROPS-VARIANTS>
               <SW-DATA-DEF-PROPS-CONDITIONAL>


### PR DESCRIPTION
in essence, this means replacing `int(my_string_value)` by `int(my_string_value, 0)`. For some reason, python does not recognize numbers that start with a 0 and continue with a digit as octal, but AUTOSAR does, so this needs to be handled as a special case.

note that with this patch, python's "0o" prefix for octal numbers is also recognized. As far as I know, AUTOSAR does not allow that, but as long as we properly recognize everything which AUTOSAR specifies, I don't see a big problem with that...

Andreas Lauser <andreas.lauser@mbition.io>, Mercedes-Benz AG on behalf of [MBition GmbH](https://mbition.io/).

[Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md#mbition-gmbh)