### PR TITLE
CLI: make loading of subparses more bullet-proof

### DIFF
--- a/cantools/__init__.py
+++ b/cantools/__init__.py
@@ -1,5 +1,6 @@
 import sys
 import argparse
+import importlib
 
 from . import tester
 from . import j1939
@@ -12,6 +13,37 @@ from .version import __version__
 
 __author__ = 'Erik Moqvist'
 
+class _ErrorSubparser:
+    def __init__(self, subparser_name, error_message):
+        self.subparser_name = subparser_name
+        self.error_message = error_message
+
+    def add_subparser(self, subparser_list):
+        err_parser = \
+            subparser_list.add_parser(self.subparser_name,
+                                      description = self.error_message)
+
+        err_parser.set_defaults(func=self._print_error)
+
+    def _print_error(self, args):
+        raise ImportError(self.error_message)
+
+def _load_subparser(subparser_name, subparsers):
+    """Load a subparser for a CLI command in a safe manner.
+
+    i.e., if the subparser cannot be loaded due to an import error or
+    similar, no exception is raised if another command was invoked on
+    the CLI."""
+
+    try:
+        result = importlib.import_module(f'.subparsers.{subparser_name}',
+                                         package=__loader__.name)
+        result.add_subparser(subparsers)
+
+    except ImportError as e:
+        result = _ErrorSubparser(subparser_name,
+                                 f'Command "{subparser_name}" is unavailable: "{e}"')
+        result.add_subparser(subparsers)
 
 def _main():
     parser = argparse.ArgumentParser(
@@ -28,21 +60,12 @@ def _main():
                                        dest='subcommand')
     subparsers.required = True
 
-    # Import when used for less dependencies. For example, curses is
-    # not part of all Python builds.
-    from .subparsers import decode
-    from .subparsers import monitor
-    from .subparsers import dump
-    from .subparsers import convert
-    from .subparsers import generate_c_source
-    from .subparsers import plot
-
-    decode.add_subparser(subparsers)
-    monitor.add_subparser(subparsers)
-    dump.add_subparser(subparsers)
-    convert.add_subparser(subparsers)
-    generate_c_source.add_subparser(subparsers)
-    plot.add_subparser(subparsers)
+    _load_subparser('decode', subparsers)
+    _load_subparser('monitor', subparsers)
+    _load_subparser('dump', subparsers)
+    _load_subparser('convert', subparsers)
+    _load_subparser('generate_c_source', subparsers)
+    _load_subparser('plot', subparsers)
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This is a generalized solution for https://github.com/eerimoq/cantools/pull/280, and IMO it even is a bit simpler. @AxelVoitier: please leave a comment what you think about this approach.

After this, if a given subparser cannot be imported for whatever reason, the CLI still works with the remaining subparsers and an error message is printed if a non-working subparser is attempted to be invoked.

Note that this patch might slightly complicate debugging subparsers because it is slightly harder to get hold of the traceback of the import error. That said, the traceback is currently not printed out-of-the-box anyway, so there will not be much difference from a developer perspective...

Andreas Lauser <andreas.lauser@mbition.io>, Mercedes-Benz AG on behalf of [MBition GmbH](https://mbition.io/).

[Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md#mbition-gmbh)