### PR TITLE
utils: do not decode a integer signal value to float if it exhibits non-fractional scaling and offset

### DIFF
--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -68,8 +68,15 @@ def _decode_field(field, value, decode_choices, scaling):
         except (KeyError, TypeError):
             pass
 
+    is_int = \
+        lambda x: x is isinstance(x, int) or (isinstance(x, float) and x.is_integer())
     if scaling:
-        return (field.scale * value + field.offset)
+        if field.is_float \
+           or not is_int(field.scale) \
+           or not is_int(field.offset):
+            return (field.scale * value + field.offset)
+        else:
+            return int(field.scale * value + field.offset)
     else:
         return value
 


### PR DESCRIPTION
Although using floating point values is probably technically correct for any decoded value, it is IMO nevertheless quite confusing if the signal in question is of integer type. In particular, this applies for the approximately 97% of all cases where no scaling or offset is specified...

Andreas Lauser <andreas.lauser@mbition.io>, Mercedes-Benz AG on behalf of [MBition GmbH](https://mbition.io/).

[Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md#mbition-gmbh)