### PR TITLE
ARXML: improved unit loading

### DIFF
--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -515,7 +515,11 @@ class SystemLoader(object):
                                                    'DISPLAY-NAME'
                                                ])
 
-        return None if res is None else res.text
+        ignorelist = ( "NoUnit", )
+
+        if res is None or res.text in ignorelist:
+            return None
+        return res.text
 
     def _load_system_signal_comments(self, system_signal):
         result = {}

--- a/tests/files/arxml/system-4.2.arxml
+++ b/tests/files/arxml/system-4.2.arxml
@@ -309,6 +309,10 @@
           <SHORT-NAME>meters</SHORT-NAME>
           <DISPLAY-NAME>m</DISPLAY-NAME>
         </UNIT>
+        <UNIT UUID="9a4019793b04d83fe7000deaf4f84144">
+          <SHORT-NAME>wizepoo</SHORT-NAME>
+          <DISPLAY-NAME>wp</DISPLAY-NAME>
+        </UNIT>
       </ELEMENTS>
     </AR-PACKAGE>
     <AR-PACKAGE UUID="bbcd842e7758802dad86635f98742e1c">
@@ -355,6 +359,7 @@
         <COMPU-METHOD UUID="dbb4bf17606b4bbaf59ccbdf80769edc">
           <SHORT-NAME>Signal6</SHORT-NAME>
           <CATEGORY>SCALE_LINEAR_AND_TEXTTABLE</CATEGORY>
+          <UNIT-REF DEST="UNIT">/Unit/wizepoo</UNIT-REF>
           <COMPU-INTERNAL-TO-PHYS>
             <COMPU-SCALES>
               <COMPU-SCALE>

--- a/tests/files/arxml/system-4.2.arxml
+++ b/tests/files/arxml/system-4.2.arxml
@@ -313,6 +313,10 @@
           <SHORT-NAME>wizepoo</SHORT-NAME>
           <DISPLAY-NAME>wp</DISPLAY-NAME>
         </UNIT>
+        <UNIT UUID="1ee6f401e0b5c0bad9d7a02ac4c64098">
+          <SHORT-NAME>zilch</SHORT-NAME>
+          <DISPLAY-NAME>NoUnit</DISPLAY-NAME>
+        </UNIT>
       </ELEMENTS>
     </AR-PACKAGE>
     <AR-PACKAGE UUID="bbcd842e7758802dad86635f98742e1c">
@@ -337,6 +341,7 @@
         <COMPU-METHOD UUID="103035ce2d0c0f33e9456fe127790243">
           <SHORT-NAME>Signal4</SHORT-NAME>
           <CATEGORY>TEXTTABLE</CATEGORY>
+          <UNIT-REF DEST="UNIT">/Unit/zilch</UNIT-REF>
           <COMPU-INTERNAL-TO-PHYS>
             <COMPU-SCALES>
               <COMPU-SCALE>

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3894,7 +3894,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_1.decimal.offset, 0.0)
         self.assertEqual(signal_1.decimal.minimum, 0)
         self.assertEqual(signal_1.decimal.maximum, 1)
-        self.assertEqual(signal_1.unit, None)
+        self.assertEqual(signal_1.unit, "wp")
         self.assertEqual(signal_1.choices, {'zero': 0})
         self.assertEqual(signal_1.comment, None)
         self.assertEqual(signal_1.is_multiplexer, False)


### PR DESCRIPTION
This makes it possible to specify the physical unit of a signal via its CompuMethod in addition to the PhysicalProps. In addition to this, an "ignore list" is introduced because the files which I have to deal with on a daily basis annoyingly use the pseudo unit "NoUnit" for signals which do not exhibit a physical unit.

Andreas Lauser <andreas.lauser@mbition.io>, Mercedes-Benz AG on behalf of [MBition GmbH](https://mbition.io/).

[Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md#mbition-gmbh)