### PR TITLE
ARXML: load the choices dictionary of texttables correctly

### DIFF
--- a/cantools/database/can/formats/arxml.py
+++ b/cantools/database/can/formats/arxml.py
@@ -556,7 +556,7 @@ class SystemLoader(object):
             if maximum is None: maximum = maximum_scale
             elif maximum_scale is not None: maximum = max(maximum, maximum_scale)
             if vt is not None:
-                choices[vt.text] = text_to_num_fn(lower_limit.text)
+                choices[int(lower_limit.text)] = vt.text
 
         decimal.minimum = minimum
         decimal.maximum = maximum
@@ -651,7 +651,7 @@ class SystemLoader(object):
 
             if vt is not None:
                 assert(minimum_scale is not None and minimum_scale == maximum_scale)
-                choices[vt.text] = minimum_scale
+                choices[int(minimum_scale)] = vt.text
 
         decimal.minimum = Decimal(minimum)
         decimal.maximum = Decimal(maximum)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3821,9 +3821,9 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_3.decimal.minimum, 0)
         self.assertEqual(signal_3.decimal.maximum, 2)
         self.assertEqual(signal_3.unit, None)
-        self.assertEqual(signal_3.choices, {'STANDARD_POSITION': 0,
-                                            'FORWARD_POSITION': 1,
-                                            'BACKWARD_POSITION': 2})
+        self.assertEqual(signal_3.choices, { 0: 'STANDARD_POSITION',
+                                             1: 'FORWARD_POSITION',
+                                             2: 'BACKWARD_POSITION'})
         self.assertEqual(signal_3.comments, None)
         self.assertEqual(signal_3.is_multiplexer, False)
         self.assertEqual(signal_3.multiplexer_ids, None)
@@ -3895,7 +3895,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_1.decimal.minimum, 0)
         self.assertEqual(signal_1.decimal.maximum, 1)
         self.assertEqual(signal_1.unit, "wp")
-        self.assertEqual(signal_1.choices, {'zero': 0})
+        self.assertEqual(signal_1.choices, {0: 'zero'})
         self.assertEqual(signal_1.comment, None)
         self.assertEqual(signal_1.is_multiplexer, False)
         self.assertEqual(signal_1.multiplexer_ids, None)
@@ -4028,7 +4028,7 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_3.decimal.minimum, 0)
         self.assertEqual(signal_3.decimal.maximum, 3)
         self.assertEqual(signal_3.unit, None)
-        self.assertEqual(signal_3.choices, {'one': 1, 'two': 2})
+        self.assertEqual(signal_3.choices, {1: 'one', 2: 'two'})
         self.assertEqual(signal_3.comment, None)
         self.assertEqual(signal_3.is_multiplexer, False)
         self.assertEqual(signal_3.multiplexer_ids, None)


### PR DESCRIPTION
For the message.decode() method to work properly, the key of the choices dictionary must be the raw signal's integer value mapped to the corresponding text, not vice-versa.

Andreas Lauser <andreas.lauser@mbition.io>, Mercedes-Benz AG on behalf of [MBition GmbH](https://mbition.io/).

[Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md#mbition-gmbh)