### PR TITLE
Fix cli usage

### DIFF
--- a/cantools/__init__.py
+++ b/cantools/__init__.py
@@ -38,7 +38,7 @@ def _load_subparser(subparser_name, subparsers):
 
     try:
         result = importlib.import_module(f'.subparsers.{subparser_name}',
-                                         package=__loader__.name)
+                                         package='cantools')
         result.add_subparser(subparsers)
 
     except ImportError as e:


### PR DESCRIPTION
The changes in this commit https://github.com/eerimoq/cantools/commit/5a9c65d9e45de36cb6c9007767cc381deac02bb6, prevented the console script working for me:

`Command "decode" is unavailable: "No module named 'cantools.__init__.subparsers'; 'cantools.__init__' is not a package"`

If calls from the script name (__init__) rather than directory. One can fix it by adding another '.': '..subparsers' but this seems messy. Since it's only going to be called from the package, it seems to make sense to just put 'cantools' in the the package field rather than using the caller name?

Now both `cantools {subparser}` and `python -m cantools {subparser}` work again.