### PR TITLE
Make parsers work with candump -a switch

### DIFF
--- a/cantools/logreader.py
+++ b/cantools/logreader.py
@@ -46,27 +46,13 @@ class BasePattern:
 
 
 class CandumpDefaultPattern(BasePattern):
+    #candump vcan0
     # vcan0  1F0   [8]  00 00 00 00 00 00 1B C1
-    pattern = re.compile(
-        r'^\s*?(?P<channel>[a-zA-Z0-9]+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>[0-9A-F ]*)$')
-
-    @staticmethod
-    def unpack(match_object):
-        channel = match_object.group('channel')
-        frame_id = int(match_object.group('can_id'), 16)
-        data = match_object.group('can_data')
-        data = data.replace(' ', '')
-        data = binascii.unhexlify(data)
-        timestamp = None
-        timestamp_format = TimestampFormat.MISSING
-
-        return DataFrame(channel=channel, frame_id=frame_id, data=data, timestamp=timestamp, timestamp_format=timestamp_format)
-
-
-class CandumpDefaultAsciiPattern(BasePattern):
+    #candump vcan0 -a
     # vcan0  1F0   [8]  00 00 00 00 00 00 1B C1   '.......Á'
+    #(Ignore anything after the end of the data to work with candump's ASCII decoding)
     pattern = re.compile(
-        r'^\s*?(?P<channel>[a-zA-Z0-9]+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>[0-9A-F ]*)\s+\'.*\'$')
+        r'^\s*?(?P<channel>[a-zA-Z0-9]+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>[0-9A-F ]*).*?$')
 
     @staticmethod
     def unpack(match_object):
@@ -82,9 +68,13 @@ class CandumpDefaultAsciiPattern(BasePattern):
 
 
 class CandumpTimestampedPattern(BasePattern):
+    #candump vcan0 -tz
     # (000.000000)  vcan0  0C8   [8]  F0 00 00 00 00 00 00 00
+    #candump vcan0 -tz -a
+    # (000.000000)  vcan0  0C8   [8]  31 30 30 2E 35 20 46 4D   '100.5 FM'
+    #(Ignore anything after the end of the data to work with candump's ASCII decoding)
     pattern = re.compile(
-        r'^\s*?\((?P<timestamp>[\d.]+)\)\s+(?P<channel>[a-zA-Z0-9]+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>[0-9A-F ]*)$')
+        r'^\s*?\((?P<timestamp>[\d.]+)\)\s+(?P<channel>[a-zA-Z0-9]+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>[0-9A-F ]*).*?$')
 
     @staticmethod
     def unpack(match_object):
@@ -109,7 +99,7 @@ class CandumpDefaultLogPattern(BasePattern):
     # (1579857014.345944) can2 486#82967A6B006B07F8
     # (1613656104.501098) can2 14C##16A0FFE00606E022400000000000000A0FFFF00FFFF25000600000000000000FE
     pattern = re.compile(
-        r'^\s*?\((?P<timestamp>[\d.]+)\)\s+(?P<channel>[a-zA-Z0-9]+)\s+(?P<can_id>[0-9A-F]+)#(#[0-9A-F])?(?P<can_data>[0-9A-F]*)$')
+        r'^\s*?\((?P<timestamp>[\d.]+)\)\s+(?P<channel>[a-zA-Z0-9]+)\s+(?P<can_id>[0-9A-F]+)#(#[0-9A-F])?(?P<can_data>[0-9A-F]*).*?$')
 
     @staticmethod
     def unpack(match_object):
@@ -125,9 +115,13 @@ class CandumpDefaultLogPattern(BasePattern):
 
 
 class CandumpAbsoluteLogPattern(BasePattern):
+    #candump vcan0 -tA
     # (2020-12-19 12:04:45.485261)  vcan0  0C8   [8]  F0 00 00 00 00 00 00 00
+    #candump vcan0 -tA -a
+    # (2020-12-19 12:04:45.485261)  vcan0  0C8   [8]  31 30 30 2E 35 20 46 4D   '100.5 FM'
+    #(Ignore anything after the end of the data to work with candump's ASCII decoding)
     pattern = re.compile(
-        r'^\s*?\((?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)\)\s+(?P<channel>[a-zA-Z0-9]+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>[0-9A-F ]*)$')
+        r'^\s*?\((?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)\)\s+(?P<channel>[a-zA-Z0-9]+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>[0-9A-F ]*).*?$')
 
     @staticmethod
     def unpack(match_object):
@@ -138,48 +132,6 @@ class CandumpAbsoluteLogPattern(BasePattern):
         data = binascii.unhexlify(data)
         timestamp = datetime.datetime.strptime(match_object.group('timestamp'), "%Y-%m-%d %H:%M:%S.%f")
         timestamp_format = TimestampFormat.ABSOLUTE
-
-        return DataFrame(channel=channel, frame_id=frame_id, data=data, timestamp=timestamp, timestamp_format=timestamp_format)
-
-
-class CandumpAsciiAbsoluteLogPattern(BasePattern):
-    # (2020-12-19 12:04:45.485261)  can1  051F0506   [8]  31 30 30 2E 35 20 46 4D   '100.5 FM'
-    pattern = re.compile(
-        r'^\s*?\((?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)\)\s+(?P<channel>[a-zA-Z0-9]+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>[0-9A-F ]*)\s+\'.*\'$')
-
-    @staticmethod
-    def unpack(match_object):
-        channel = match_object.group('channel')
-        frame_id = int(match_object.group('can_id'), 16)
-        data = match_object.group('can_data')
-        data = data.replace(' ', '')
-        data = binascii.unhexlify(data)
-        timestamp = datetime.datetime.strptime(match_object.group('timestamp'), "%Y-%m-%d %H:%M:%S.%f")
-        timestamp_format = TimestampFormat.ABSOLUTE
-
-        return DataFrame(channel=channel, frame_id=frame_id, data=data, timestamp=timestamp, timestamp_format=timestamp_format)
-
-
-class CandumpAsciiAbsoluteTimestampedPattern(BasePattern):
-    # (1621270556.960879)  can1  051F0506   [8]  31 30 30 2E 35 20 46 4D   '100.5 FM'
-    pattern = re.compile(
-        r'^\s*?\((?P<timestamp>[\d.]+)\)\s+(?P<channel>[a-zA-Z0-9]+)\s+(?P<can_id>[0-9A-F]+)\s+\[\d+\]\s*(?P<can_data>[0-9A-F ]*)\s+\'.*\'$')
-
-    @staticmethod
-    def unpack(match_object):
-        channel = match_object.group('channel')
-        frame_id = int(match_object.group('can_id'), 16)
-        data = match_object.group('can_data')
-        data = data.replace(' ', '')
-        data = binascii.unhexlify(data)
-
-        seconds = float(match_object.group('timestamp'))
-        if seconds < 662688000:  # 1991-01-01 00:00:00, "Released in 1991, the Mercedes-Benz W140 was the first production vehicle to feature a CAN-based multiplex wiring system."
-            timestamp = datetime.timedelta(seconds=seconds)
-            timestamp_format = TimestampFormat.RELATIVE
-        else:
-            timestamp = datetime.datetime.utcfromtimestamp(seconds)
-            timestamp_format = TimestampFormat.ABSOLUTE
 
         return DataFrame(channel=channel, frame_id=frame_id, data=data, timestamp=timestamp, timestamp_format=timestamp_format)
 
@@ -201,7 +153,7 @@ class Parser:
 
     @staticmethod
     def detect_pattern(line):
-        for p in [CandumpDefaultPattern, CandumpDefaultAsciiPattern, CandumpTimestampedPattern, CandumpDefaultLogPattern, CandumpAbsoluteLogPattern, CandumpAsciiAbsoluteTimestampedPattern, CandumpAsciiAbsoluteLogPattern]:
+        for p in [CandumpDefaultPattern, CandumpTimestampedPattern, CandumpDefaultLogPattern, CandumpAbsoluteLogPattern]:
             mo = p.pattern.match(line)
             if mo:
                 return p

--- a/tests/test_logreader.py
+++ b/tests/test_logreader.py
@@ -134,6 +134,24 @@ class TestLogreaderFormats(unittest.TestCase):
         self.assertEqual(outp.timestamp.second, 45)
         self.assertEqual(outp.timestamp.microsecond, 485261)
 
+    def test_candump_log_ascii(self):
+        parser = cantools.logreader.Parser()
+
+        outp = parser.parse(" can1  123   [8]  31 30 30 2E 35 20 46 4D   '100.5 FM'")
+        self.assertEqual(outp.channel, 'can1')
+        self.assertEqual(outp.frame_id, 0x123)
+        self.assertEqual(outp.data, b'\x31\x30\x30\x2E\x35\x20\x46\x4D')
+        self.assertEqual(outp.timestamp_format, cantools.logreader.TimestampFormat.MISSING)
+
+    def test_candump_log_ascii_timestamped(self):
+        parser = cantools.logreader.Parser()
+
+        outp = parser.parse("  (1621271100.919019)  can1  123   [8]  31 30 30 2E 35 20 46 4D   '100.5 FM'")
+        self.assertEqual(outp.channel, 'can1')
+        self.assertEqual(outp.frame_id, 0x123)
+        self.assertEqual(outp.data, b'\x31\x30\x30\x2E\x35\x20\x46\x4D')
+        self.assertEqual(outp.timestamp_format, cantools.logreader.TimestampFormat.ABSOLUTE)
+
 
 class TestLogreaderStreams(unittest.TestCase):
     def test_candump(self):

--- a/tests/test_logreader.py
+++ b/tests/test_logreader.py
@@ -152,6 +152,22 @@ class TestLogreaderFormats(unittest.TestCase):
         self.assertEqual(outp.data, b'\x31\x30\x30\x2E\x35\x20\x46\x4D')
         self.assertEqual(outp.timestamp_format, cantools.logreader.TimestampFormat.ABSOLUTE)
 
+    def test_candump_log_ascii_absolute(self):
+        parser = cantools.logreader.Parser()
+
+        outp = parser.parse("(2020-12-19 12:04:45.485261)  can1  123   [8]  31 30 30 2E 35 20 46 4D   '100.5 FM'")
+        self.assertEqual(outp.channel, 'can1')
+        self.assertEqual(outp.frame_id, 0x123)
+        self.assertEqual(outp.data, b'\x31\x30\x30\x2E\x35\x20\x46\x4D')
+        self.assertEqual(outp.timestamp_format, cantools.logreader.TimestampFormat.ABSOLUTE)
+        self.assertEqual(outp.timestamp.year, 2020)
+        self.assertEqual(outp.timestamp.month, 12)
+        self.assertEqual(outp.timestamp.day, 19)
+        self.assertEqual(outp.timestamp.hour, 12)
+        self.assertEqual(outp.timestamp.minute, 4)
+        self.assertEqual(outp.timestamp.second, 45)
+        self.assertEqual(outp.timestamp.microsecond, 485261)
+
 
 class TestLogreaderStreams(unittest.TestCase):
     def test_candump(self):


### PR DESCRIPTION
I found myself working on a CAN system that sends bits of ASCII every now and then, so it was helpful to use the `candump -a` switch.

This PR adds a few parsers compatible with the default (non-timestamped) and timestamped (-t a / -t z / -t A) outputs when using the -a switch. By compatible, I mean they don't do anything with it (since you can just look at it yourself in the data array), but they parse the rest of the line correctly.

That way, cantools decode can be used in conjunction with candump -a