### PR TITLE
attempt to fix the recently appearing test failures of PRs

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,9 +29,9 @@ jobs:
         make test-c-clean
         make test-c
         make test-c-clean
-        CC=gcc-8 make test-c
+        CC=gcc make test-c
         make test-c-clean
-        CC=clang-8 make test-c-src
+        CC=clang make test-c-src
     - name: Coveralls
       uses: AndreMiras/coveralls-python-action@develop
 

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ CFLAGS_EXTRA_CLANG := \
 	-Wzero-length-array
 
 CFLAGS := \
+	-std=c99 \
 	-Wall \
 	-Wextra \
 	-Wdouble-promotion \


### PR DESCRIPTION
the assumption is of this PR that these errors are caused because github-CI recently removed gcc-8 and -- maybe -- clang-8.

While I see the point of using older compilers to ensure that they stay supported, the code to be compiled is based on the C99 standard which ought to be very seasoned for at least a decade, i.e., I would be *very* surprised if compilers introduced major incompatibilities with this code in the future. IOW, let's just use the default versions of the host system...

Signed-off-by: Andreas Lauser <andreas.lauser@mbition.io>
Signed-off-by: Oliver Kopp <oliver.kopp@mbition.io>