### PR TITLE
implement comments for named signal values

### DIFF
--- a/cantools/database/can/c_source.py
+++ b/cantools/database/can/c_source.py
@@ -607,7 +607,7 @@ class Signal(object):
         """
 
         items = {
-            value: camel_to_snake_case(name).upper()
+            value: camel_to_snake_case(str(name)).upper()
             for value, name in self.choices.items()
         }
         names = list(items.values())
@@ -1162,7 +1162,7 @@ def _format_choices(signal, signal_name):
             fmt = '{signal_name}_{name}_CHOICE ({value}u)'
 
         choices.append(fmt.format(signal_name=signal_name.upper(),
-                                  name=name,
+                                  name=str(name),
                                   value=value))
 
     return choices

--- a/cantools/database/can/formats/dbc.py
+++ b/cantools/database/can/formats/dbc.py
@@ -23,6 +23,7 @@ from textparser import Optional
 from ..attribute_definition import AttributeDefinition
 from ..attribute import Attribute
 from ..signal import Signal
+from ..signal import NamedSignalValue
 from ..signal import Decimal as SignalDecimal
 from ..signal_group import SignalGroup
 from ..message import Message
@@ -981,7 +982,8 @@ def _load_value_tables(tokens):
 
     for value_table in tokens.get('VAL_TABLE_', []):
         name = value_table[1]
-        choices = {int(number): text for number, text in value_table[2]}
+        choices = {int(number): NamedSignalValue(number, text) for number, text in value_table[2]}
+        #choices = {int(number): text for number, text in value_table[2]}
         value_tables[name] = choices
 
     return value_tables
@@ -1013,7 +1015,7 @@ def _load_choices(tokens):
         if len(choice[1]) == 0:
             continue
 
-        od = odict((int(''.join(v[0])), v[1]) for v in choice[3])
+        od = odict((int(v[0]), NamedSignalValue(v[0], v[1])) for v in choice[3])
 
         if len(od) == 0:
             continue

--- a/cantools/database/can/formats/kcd.py
+++ b/cantools/database/can/formats/kcd.py
@@ -10,6 +10,7 @@ from xml.etree.ElementTree import Element
 from xml.etree.ElementTree import SubElement
 
 from ..signal import Signal
+from ..signal import NamedSignalValue
 from ..signal import Decimal as SignalDecimal
 from ..message import Message
 from ..node import Node
@@ -117,7 +118,7 @@ def _load_signal_element(signal, nodes):
         for label in label_set.iterfind('ns:Label', NAMESPACES):
             label_value = int(label.attrib['value'])
             label_name = label.attrib['name']
-            labels[label_value] = label_name
+            labels[label_value] = NamedSignalValue(label_value, label_name)
 
         # TODO: Label groups.
 
@@ -333,7 +334,7 @@ def _dump_signal(signal, node_refs, signal_element):
         label_set = SubElement(signal_element, 'LabelSet')
 
         for value, name in signal.choices.items():
-            SubElement(label_set, 'Label', name=name, value=str(value))
+            SubElement(label_set, 'Label', name=str(name), value=str(value))
 
 
 def _dump_mux_group(multiplexer_id,

--- a/cantools/database/can/formats/sym.py
+++ b/cantools/database/can/formats/sym.py
@@ -18,6 +18,7 @@ from textparser import Optional
 from textparser import Any
 
 from ..signal import Signal
+from ..signal import NamedSignalValue
 from ..signal import Decimal as SignalDecimal
 from ..message import Message
 from ..internal_database import InternalDatabase
@@ -256,15 +257,21 @@ def _get_enum(enums, name):
 
 def _load_enums(tokens):
     section = _get_section_tokens(tokens, '{ENUMS}')
-    enums = {}
+    all_enums = {}
 
     for _, _, name, _, values, _, _ in section:
         if values:
             values = values[0]
 
-        enums[name] = odict((num(v[0]), v[2]) for v in values)
+        enum = odict()
+        for v in values:
+            value = num(v[0])
+            value_name = v[2]
+            enum[value] = NamedSignalValue(value, value_name)
 
-    return enums
+        all_enums[name] = enum
+
+    return all_enums
 
 
 def _load_signal_type_and_length(type_, tokens, enums):

--- a/cantools/database/can/message.py
+++ b/cantools/database/can/message.py
@@ -3,6 +3,8 @@
 import binascii
 from copy import deepcopy
 
+from .signal import NamedSignalValue
+
 from ..utils import format_or
 from ..utils import start_bit
 from ..utils import encode_data
@@ -338,7 +340,7 @@ class Message(object):
     def _get_mux_number(self, decoded, signal_name):
         mux = decoded[signal_name]
 
-        if isinstance(mux, str):
+        if isinstance(mux, str) or isinstance(mux, NamedSignalValue):
             signal = self.get_signal_by_name(signal_name)
             mux = signal.choice_string_to_number(mux)
 

--- a/cantools/database/can/signal.py
+++ b/cantools/database/can/signal.py
@@ -67,6 +67,69 @@ class Decimal(object):
     def maximum(self, value):
         self._maximum = value
 
+class NamedSignalValue(object):
+    """Represents a named value of a signal.
+
+    Named values map an integer number to a human-readable
+    string. Some file formats like ARXML support specifying
+    descriptions for the named value.
+    """
+
+    def __init__(self, value, name, comments = {}):
+        self._name = name
+        self._value = value
+        self._comments = comments
+
+    @property
+    def name(self):
+        """The text intended for human consumption which the specified integer
+        is mapped to.
+        """
+
+        return self._name
+
+    @property
+    def value(self):
+        """The integer value that gets mapped
+        """
+
+        return self._value
+
+    @property
+    def comments(self):
+        """The descriptions of the named value
+
+        This is a dictionary containing the descriptions in multiple
+        languagues. The dictionary is indexed by the language.
+
+        Example:
+
+        .. code:: text
+
+          # retrieve the English comment of the named value or an empty
+          # string if none was specified.
+          named_value.comments.get("EN", "")
+
+        """
+
+        return self._comments
+
+    def __str__(self):
+        return self._name
+
+    def __repr__(self):
+        return f"{self._name}"
+
+    def __eq__(self, x):
+        if isinstance(x, NamedSignalValue):
+            return \
+                x.value == self.value \
+                and x.name == self.name \
+                and x.comments == self.comments
+        elif isinstance(x, str):
+            return x == self.name
+
+        return False
 
 class Signal(object):
     """A CAN signal with position, size, unit and other information. A
@@ -434,8 +497,8 @@ class Signal(object):
         self._spn = value
 
     def choice_string_to_number(self, string):
-        for choice_number, choice_string in self.choices.items():
-            if choice_string == string:
+        for choice_number, choice_value in self.choices.items():
+            if str(choice_value) == str(string):
                 return choice_number
 
     def __repr__(self):

--- a/cantools/subparsers/utils.py
+++ b/cantools/subparsers/utils.py
@@ -1,3 +1,5 @@
+from cantools.database.can.signal import NamedSignalValue
+
 MULTI_LINE_FMT = '''
 {message}(
 {signals}
@@ -14,8 +16,8 @@ def _format_signals(message, decoded_signals):
         except KeyError:
             continue
 
-        if isinstance(value, str):
-            value = "'{}'".format(value)
+        if isinstance(value, NamedSignalValue) or isinstance(value, str):
+            value = f"'{value}'"
 
         signal_name = signal.name
 

--- a/tests/files/arxml/system-4.2.arxml
+++ b/tests/files/arxml/system-4.2.arxml
@@ -351,6 +351,10 @@
               <COMPU-SCALE>
                 <LOWER-LIMIT>1</LOWER-LIMIT>
                 <UPPER-LIMIT>1</UPPER-LIMIT>
+                <DESC>
+                  <L-2 L="EN">One Comment</L-2>
+                  <L-2 L="DE">Ein Kommentar</L-2>
+                </DESC>
                 <COMPU-CONST><VT>one</VT></COMPU-CONST>
               </COMPU-SCALE>
               <COMPU-SCALE>
@@ -370,6 +374,10 @@
               <COMPU-SCALE>
                 <LOWER-LIMIT>0</LOWER-LIMIT>
                 <UPPER-LIMIT>0</UPPER-LIMIT>
+                <DESC>
+                  <L-2 L="EN">Nothing</L-2>
+                  <L-2 L="DE">Nichts</L-2>
+                </DESC>
                 <COMPU-CONST><VT>zero</VT></COMPU-CONST>
               </COMPU-SCALE>
               <COMPU-SCALE>

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -21,11 +21,25 @@ except ImportError:
 import cantools
 from cantools.database.can.formats import dbc
 from cantools.database import UnsupportedDatabaseFormatError
-
-
+from cantools.database.can.signal import NamedSignalValue
+  
 class CanToolsDatabaseTest(unittest.TestCase):
 
     maxDiff = None
+
+    def assertEqualChoicesDictHelper_(self, have, expect):
+        if have.keys() != expect.keys():
+            raise AssertationError(f'keys differ: {have} != {expect}')
+
+        for key in have.keys():
+            self.assertEqual(str(have[key]), str(expect[key]))
+
+    def assertEqualChoicesDict(self, have, expect):
+        if have.keys() != expect.keys():
+            raise AssertationError(f'keys differ: {have.keys()} != {expect.keys()}')
+
+        for key in have.keys():
+            self.assertEqualChoicesDictHelper_(have[key], expect[key])
 
     def assert_dbc_dump(self, db, filename):
         actual = db.as_dbc_string()
@@ -4029,6 +4043,8 @@ class CanToolsDatabaseTest(unittest.TestCase):
         self.assertEqual(signal_3.decimal.maximum, 3)
         self.assertEqual(signal_3.unit, None)
         self.assertEqual(signal_3.choices, {1: 'one', 2: 'two'})
+        self.assertEqual(signal_3.choices[1].comments,
+                         {'EN': 'One Comment', 'DE': 'Ein Kommentar'})
         self.assertEqual(signal_3.comment, None)
         self.assertEqual(signal_3.is_multiplexer, False)
         self.assertEqual(signal_3.multiplexer_ids, None)


### PR DESCRIPTION
Some file formats (err, ARXML) support this, and I occasionally consider these additional explanations to be useful.

This patch works by introducing a new class called `NamedSignalValue` and the signal choices dictionaries map to objects of it instead of raw strings. In most respects `NamedSignalValue` objects behave just like strings, but in addition they exhibit a `.comments` attribute which maps a language name to the comment für this language (just like the comments for `Signal` and `Message` objects).

Andreas Lauser <andreas.lauser@mbition.io> on behalf of [MBition GmbH](https://mbition.io/).

[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md#mbition-gmbh)