### PR TITLE
CLI: fix output in case of error

### DIFF
--- a/cantools/__init__.py
+++ b/cantools/__init__.py
@@ -23,6 +23,7 @@ class _ErrorSubparser:
         err_parser = \
             subparser_list.add_parser(self.subparser_name,
                                       description = self.error_message)
+        err_parser.add_argument("args", nargs="*")
 
         err_parser.set_defaults(func=self._print_error)
 


### PR DESCRIPTION
The problem here was that the error subparser did not ignore the additional parameters intended to be passed to the actual subparser. This lead to *very* confusing error messages if additional parameters were passed to a subparser that could not be loaded.

Andreas Lauser <andreas.lauser@mbition.io> on behalf of [MBition GmbH](https://mbition.io/).

[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md#mbition-gmbh)