### PR TITLE
Test with the default gcc version

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,9 +29,9 @@ jobs:
         make test-c-clean
         make test-c
         make test-c-clean
-        CC=gcc-8 make test-c
+        CC=gcc make test-c
         make test-c-clean
-        CC=clang-8 make test-c-src
+        CC=clang make test-c-src
     - name: Coveralls
       uses: AndreMiras/coveralls-python-action@develop
 


### PR DESCRIPTION
gcc-8 doesn't seem to be available on `ubuntu-latest`, causing the tests to fail. Haven't investigated since when and why though. Should we just use the default gcc version bundled for testing?