### PR TITLE
Define is_int only when it is needed

### DIFF
--- a/cantools/database/utils.py
+++ b/cantools/database/utils.py
@@ -68,9 +68,9 @@ def _decode_field(field, value, decode_choices, scaling):
         except (KeyError, TypeError):
             pass
 
-    is_int = \
-        lambda x: x is isinstance(x, int) or (isinstance(x, float) and x.is_integer())
     if scaling:
+        is_int = \
+            lambda x: isinstance(x, int) or (isinstance(x, float) and x.is_integer())
         if field.is_float \
            or not is_int(field.scale) \
            or not is_int(field.offset):


### PR DESCRIPTION
is_int is only needed when scaling is True, otherwise it is defined and never used.

Also I deleted the `x is` which I believe to be a bug, because the function does not give the correct output for an int e.g 2.

I'm not sure whether `if scaling` should `elif scaling`